### PR TITLE
docs: Update documentation for multi-task platform identity

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "MLNet.Embeddings.Onnx",
+    "name": "MLNet.TextInference.Onnx",
     "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
     "hostRequirements": {
         "gpu": "optional"

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,12 @@ bld/
 # Tokenizer vocab files (downloaded with models)
 samples/*/models/*.txt
 
+# Future task sample model directories
+samples/Classification/*/models/
+samples/NER/*/models/
+samples/Reranking/*/models/
+samples/QA/*/models/
+
 # ML.NET saved models
 *.mlnet
 *.zip

--- a/README.md
+++ b/README.md
@@ -1,34 +1,55 @@
-# MLNet.Embeddings.Onnx
+# ML.NET Text Inference Custom Transforms
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/luisquintanilla/mlnet-embedding-custom-transforms?quickstart=1)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/luisquintanilla/mlnet-text-inference-custom-transforms?quickstart=1)
 
-A custom ML.NET `IEstimator` / `ITransformer` that generates text embeddings using local HuggingFace ONNX models. Provides both a **convenience facade** (single estimator) and a **composable modular pipeline** (three independent transforms) for tokenization, ONNX inference, pooling, and normalization.
+A **multi-task text inference platform** for ML.NET that runs local HuggingFace ONNX encoder models. Provides a shared foundation of tokenization + ONNX scoring, with task-specific post-processing transforms for embeddings, classification, NER, reranking, question answering, and more.
 
 ```
-                                            ┌─ MeanPooling ─┐
-Raw text → [TextTokenizer] → token IDs  →  [OnnxScorer] → [Pooling] → L2-normalized embedding
-           (BPE / WordPiece)   + masks      (ONNX Runtime)  └─ CLS / Max ─┘
+                    TextTokenizerTransformer
+                            │
+                            ▼
+                 OnnxTextModelScorerTransformer       (task-agnostic)
+                            │
+            ┌───────────────┼────────────────┐
+            │               │                │
+     EmbeddingPooling  SoftmaxClassify  (more tasks)
+     Transformer       Transformer      coming soon
 ```
+
+## Task Status
+
+| Task | Status | Post-processor | Facade |
+|------|--------|---------------|--------|
+| Embeddings | ✅ Implemented | `EmbeddingPoolingTransformer` | `OnnxTextEmbeddingEstimator` |
+| Classification | 🔲 Planned | `SoftmaxClassificationTransformer` | `OnnxTextClassificationEstimator` |
+| Reranking | 🔲 Planned | `SigmoidScorerTransformer` | `OnnxRerankerEstimator` |
+| NER | 🔲 Planned | `NerDecodingTransformer` | `OnnxNerEstimator` |
+| QA | 🔲 Planned | `QaSpanExtractionTransformer` | `OnnxQaEstimator` |
+| Text Generation | 🔲 Planned | `ChatClientTransformer` | N/A |
 
 ## Why This Exists
 
-ML.NET has no built-in transform for modern HuggingFace embedding models (all-MiniLM-L6-v2, BGE, E5, etc.). Building one is hard because ML.NET's convenient internal base classes (`RowToRowTransformerBase`, `OneToOneTransformerBase`) have `private protected` constructors — they can't be subclassed from external projects.
+This project is forked from [`mlnet-embedding-custom-transforms`](https://github.com/luisquintanilla/mlnet-embedding-custom-transforms), which provides embedding generation only. This fork extends the platform to support **all encoder transformer tasks** — embeddings, classification, NER, reranking, and question answering — by sharing a task-agnostic tokenization and ONNX scoring foundation and adding task-specific post-processing transforms.
 
-This project implements a custom transform using direct `IEstimator<T>` / `ITransformer` interfaces (Approach C from the [ML.NET Custom Transformer Guide](https://github.com/luisquintanilla/mlnet-custom-transformer-guide)), enhanced with custom zip-based save/load for model persistence.
+ML.NET has no built-in transform for modern HuggingFace encoder models (all-MiniLM-L6-v2, BGE, E5, DeBERTa, etc.). Building one is hard because ML.NET's convenient internal base classes (`RowToRowTransformerBase`, `OneToOneTransformerBase`) have `private protected` constructors — they can't be subclassed from external projects.
+
+This project implements custom transforms using direct `IEstimator<T>` / `ITransformer` interfaces (Approach C from the [ML.NET Custom Transformer Guide](https://github.com/luisquintanilla/mlnet-custom-transformer-guide)), enhanced with custom zip-based save/load for model persistence.
 
 ## Features
 
-- **Composable modular pipeline** — three independent transforms (`TokenizeText → ScoreOnnxTextModel → PoolEmbedding`) that can be inspected, swapped, and reused
-- **Convenience facade** — `OnnxTextEmbeddingEstimator` wraps all three transforms in a single call
+- **Composable modular pipeline** — task-agnostic transforms (`TokenizeText → ScoreOnnxTextModel`) plus task-specific post-processing that can be inspected, swapped, and reused
+- **Convenience facades** — `OnnxTextEmbeddingEstimator` wraps all transforms for embeddings in a single call; more task facades planned
 - **Provider-agnostic MEAI integration** — `EmbeddingGeneratorEstimator` wraps any `IEmbeddingGenerator<string, Embedding<float>>` as an ML.NET transform
 - **Smart tokenizer resolution** — point to a directory; auto-detects from `tokenizer_config.json` or known vocab files (BPE, SentencePiece, WordPiece)
-- **ONNX auto-discovery** — automatically detects input/output tensor names, shapes, and embedding dimensions from model metadata
+- **ONNX auto-discovery** — automatically detects input/output tensor names, shapes, and dimensions from model metadata
 - **Self-contained save/load** — serializes to a portable `.mlnet` zip file containing the ONNX model, tokenizer, and config
-- **SIMD-accelerated pooling** — mean pooling and L2 normalization use `TensorPrimitives` for hardware-vectorized math
+- **SIMD-accelerated post-processing** — pooling and normalization use `TensorPrimitives` for hardware-vectorized math
 - **Configurable batching** — process rows in configurable batch sizes to bound memory usage
-- **Multiple pooling strategies** — Mean, CLS token, and Max pooling
+- **Multiple pooling strategies** — Mean, CLS token, and Max pooling (for embeddings)
 
-## Quickstart
+## Quick Start (Embeddings)
+
+> **Note:** Embeddings are the first implemented task. More tasks (classification, NER, reranking, QA) are coming soon — each will follow the same pattern of shared tokenization + scoring with a task-specific post-processing transform.
 
 ### 1. Get the model files
 
@@ -46,7 +67,7 @@ Invoke-WebRequest -Uri "https://huggingface.co/sentence-transformers/all-MiniLM-
 
 ```csharp
 using Microsoft.ML;
-using MLNet.Embeddings.Onnx;
+using MLNet.TextInference.Onnx;
 
 var mlContext = new MLContext();
 var data = mlContext.Data.LoadFromEnumerable(new[]
@@ -120,21 +141,49 @@ transformer.Save("my-embedding-model.mlnet");
 var loaded = OnnxTextEmbeddingTransformer.Load(mlContext, "my-embedding-model.mlnet");
 ```
 
+## Model Compatibility
+
+The shared foundation supports any encoder transformer ONNX model. Compatible model architectures include:
+
+- **BERT** and derivatives (all-MiniLM, all-mpnet)
+- **RoBERTa** (including XLM-RoBERTa for multilingual)
+- **DistilBERT**
+- **DeBERTa** / DeBERTa-v2
+- **MiniLM** (Microsoft)
+- **MPNet** (Microsoft)
+- **E5** (intfloat)
+- **BGE** (BAAI)
+- **GTE** (Alibaba)
+
+### Tested Embedding Models
+
+| Model | Dimensions | Size | Tested | Sample |
+|-------|:----------:|:----:|:------:|--------|
+| [all-MiniLM-L6-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) | 384 | ~86 MB | ✅ | [BasicUsage](samples/BasicUsage/) |
+| [BAAI/bge-small-en-v1.5](https://huggingface.co/BAAI/bge-small-en-v1.5) | 384 | ~127 MB | ✅ | [BgeSmallEmbedding](samples/BgeSmallEmbedding/) |
+| [intfloat/e5-small-v2](https://huggingface.co/intfloat/e5-small-v2) | 384 | ~127 MB | ✅ | [E5SmallEmbedding](samples/E5SmallEmbedding/) |
+| [thenlper/gte-small](https://huggingface.co/thenlper/gte-small) | 384 | ~127 MB | ✅ | [GteSmallEmbedding](samples/GteSmallEmbedding/) |
+| [all-MiniLM-L12-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L12-v2) | 384 | ~120 MB | — | |
+| [all-mpnet-base-v2](https://huggingface.co/sentence-transformers/all-mpnet-base-v2) | 768 | ~420 MB | — | |
+
+Models with `sentence_embedding` output (pre-pooled) are auto-detected and pooling is skipped.
+
 ## Project Structure
 
 ```
-mlnet-embedding-custom-transforms/
-├── src/MLNet.Embeddings.Onnx/
+mlnet-text-inference-custom-transforms/
+├── src/MLNet.TextInference.Onnx/
 │   ├── TextTokenizerEstimator.cs         — Transform 1: tokenization (BPE/WordPiece/SentencePiece)
 │   ├── OnnxTextModelScorerEstimator.cs   — Transform 2: ONNX inference with lookahead batching
-│   ├── EmbeddingPoolingEstimator.cs      — Transform 3: pooling + L2 normalization
-│   ├── OnnxTextEmbeddingEstimator.cs     — Convenience facade (chains all three)
-│   ├── EmbeddingGeneratorEstimator.cs    — Provider-agnostic MEAI wrapper
-│   ├── OnnxEmbeddingGenerator.cs         — MEAI IEmbeddingGenerator for ONNX models
-│   ├── MLContextExtensions.cs            — Extension methods for fluent API
-│   ├── EmbeddingPooling.cs               — SIMD-accelerated pooling via TensorPrimitives
-│   ├── ModelPackager.cs                  — Save/load to self-contained zip
-│   └── PoolingStrategy.cs               — Mean / CLS / Max pooling enum
+│   ├── Embeddings/
+│   │   ├── EmbeddingPoolingEstimator.cs  — Transform 3: pooling + L2 normalization
+│   │   ├── OnnxTextEmbeddingEstimator.cs — Convenience facade (chains all three)
+│   │   ├── EmbeddingGeneratorEstimator.cs— Provider-agnostic MEAI wrapper
+│   │   ├── OnnxEmbeddingGenerator.cs     — MEAI IEmbeddingGenerator for ONNX models
+│   │   ├── EmbeddingPooling.cs           — SIMD-accelerated pooling via TensorPrimitives
+│   │   ├── ModelPackager.cs              — Save/load to self-contained zip
+│   │   └── PoolingStrategy.cs            — Mean / CLS / Max pooling enum
+│   └── MLContextExtensions.cs            — Extension methods for fluent API
 ├── samples/
 │   ├── BasicUsage/                       — all-MiniLM-L6-v2: all API surfaces
 │   ├── BgeSmallEmbedding/                — BGE-small: query prefix pattern
@@ -144,10 +193,11 @@ mlnet-embedding-custom-transforms/
 │   ├── IntermediateInspection/           — Inspect tokens, masks, raw output
 │   └── MeaiProviderAgnostic/             — Provider-agnostic MEAI transform
 ├── docs/                                 — Detailed documentation
-│   ├── design-decisions.md               — Why every choice was made
+│   ├── architecture-decision-record.md   — ADR for multi-task platform decisions
 │   ├── architecture.md                   — Component walkthrough + pipeline stages
+│   ├── design-decisions.md               — Why every choice was made
+│   ├── extending.md                      — How to modify, extend, and add new tasks
 │   ├── tensor-deep-dive.md               — System.Numerics.Tensors for AI workloads
-│   ├── extending.md                      — How to modify and extend
 │   └── references.md                     — All sources and further reading
 ├── proposals/                            — Design proposals for the modular architecture
 └── nuget.config                          — NuGet source (nuget.org only)
@@ -172,25 +222,10 @@ mlnet-embedding-custom-transforms/
 | `TextTokenizerEstimator` | Transform 1: Tokenization | `Fit(IDataView)` |
 | `OnnxTextModelScorerEstimator` | Transform 2: ONNX Scoring | `Fit(IDataView)` → `.HiddenDim`, `.HasPooledOutput` |
 | `EmbeddingPoolingEstimator` | Transform 3: Pooling | `Fit(IDataView)` |
-| `OnnxTextEmbeddingEstimator` | Facade (chains 1→2→3) | `Fit(IDataView)`, `GetOutputSchema()` |
-| `OnnxTextEmbeddingTransformer` | Facade transformer | `Transform(IDataView)`, `Save(path)`, `Load(ctx, path)` |
+| `OnnxTextEmbeddingEstimator` | Embedding Facade (chains 1→2→3) | `Fit(IDataView)`, `GetOutputSchema()` |
+| `OnnxTextEmbeddingTransformer` | Embedding Facade transformer | `Transform(IDataView)`, `Save(path)`, `Load(ctx, path)` |
 | `EmbeddingGeneratorEstimator` | MEAI wrapper transform | `Fit(IDataView)` |
 | `OnnxEmbeddingGenerator` | MEAI `IEmbeddingGenerator` | `GenerateAsync(texts)` |
-
-## Supported Models
-
-Any sentence-transformer ONNX model that follows the standard input/output convention:
-
-| Model | Dimensions | Size | Tested | Sample |
-|-------|:----------:|:----:|:------:|--------|
-| [all-MiniLM-L6-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) | 384 | ~86 MB | ✅ | [BasicUsage](samples/BasicUsage/) |
-| [BAAI/bge-small-en-v1.5](https://huggingface.co/BAAI/bge-small-en-v1.5) | 384 | ~127 MB | ✅ | [BgeSmallEmbedding](samples/BgeSmallEmbedding/) |
-| [intfloat/e5-small-v2](https://huggingface.co/intfloat/e5-small-v2) | 384 | ~127 MB | ✅ | [E5SmallEmbedding](samples/E5SmallEmbedding/) |
-| [thenlper/gte-small](https://huggingface.co/thenlper/gte-small) | 384 | ~127 MB | ✅ | [GteSmallEmbedding](samples/GteSmallEmbedding/) |
-| [all-MiniLM-L12-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L12-v2) | 384 | ~120 MB | — | |
-| [all-mpnet-base-v2](https://huggingface.co/sentence-transformers/all-mpnet-base-v2) | 768 | ~420 MB | — | |
-
-Models with `sentence_embedding` output (pre-pooled) are auto-detected and pooling is skipped.
 
 ## GPU Support (CUDA)
 
@@ -281,13 +316,11 @@ When `FallbackToCpu = true`, if CUDA initialization fails the estimator silently
 
 ## Documentation
 
-For detailed documentation on the design, architecture, and implementation:
-
 - **[Architecture Decision Record](docs/architecture-decision-record.md)** — Why this repo exists and the platform architecture
-- **[Design Decisions](docs/design-decisions.md)** — Why every choice was made
 - **[Architecture](docs/architecture.md)** — Component walkthrough and pipeline stages
+- **[Design Decisions](docs/design-decisions.md)** — Why every choice was made
+- **[Extending](docs/extending.md)** — How to modify, extend, and add new tasks
 - **[Tensor Deep Dive](docs/tensor-deep-dive.md)** — System.Numerics.Tensors for AI workloads
-- **[Extending](docs/extending.md)** — How to modify, extend, and harden
 - **[References](docs/references.md)** — All sources and further reading
 
 ## Target Framework

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,29 @@
 # Architecture
 
-This document walks through every component in the solution and traces the data flow from raw text to final embedding vector. Code references point to the actual source files.
+This document walks through every component in the `MLNet.TextInference.Onnx` solution and traces the data flow from raw text to task-specific output. The architecture is built on a **shared foundation** of tokenization and ONNX scoring, with task-specific post-processing transforms plugged in for each downstream task (embeddings, classification, NER, reranking, QA).
+
+## Shared Foundation
+
+The platform is built on two task-agnostic transforms that are shared across **all** encoder transformer tasks:
+
+1. **`TextTokenizerTransformer`** — Converts raw text into token IDs, attention masks, and token type IDs. Supports BPE, WordPiece, and SentencePiece via smart resolution from HuggingFace model directories.
+
+2. **`OnnxTextModelScorerTransformer`** — Runs the tokenized input through an ONNX encoder model (BERT, RoBERTa, DeBERTa, MiniLM, etc.) and produces raw model output. Uses lookahead batching for efficient ONNX inference while maintaining lazy cursor-based evaluation.
+
+Each task then adds a **post-processing transform** that interprets the raw model output for a specific purpose (pooling for embeddings, softmax for classification, BIO decoding for NER, etc.), plus a **convenience facade** that chains all three transforms together.
+
+### The Facade Pattern
+
+Each task provides a facade estimator that wraps the full pipeline (tokenizer → scorer → post-processor) in a single call. This preserves a simple API for common use cases while allowing advanced users to compose the transforms directly.
+
+### The "Two Faces" Pattern
+
+Each transform exposes two APIs:
+
+- **ML.NET face** (`Transform(IDataView)`): Lazy, wraps input. Returns a wrapping IDataView — no data is materialized. Used by ML.NET pipelines and `.Append()` chains.
+- **Direct face** (`Tokenize()`, `Score()`, `Pool()`): Eager, processes batches directly. Used by `GenerateEmbeddings()` and `OnnxEmbeddingGenerator` for zero-overhead batch processing.
+
+Code references point to the actual source files in `src/MLNet.TextInference.Onnx/`.
 
 ## Component Map
 
@@ -100,6 +123,18 @@ EmbeddingPoolingTransformer:
 Output IDataView
 ```
 
+## How Each Task Plugs In
+
+The shared foundation produces raw model output. Each task adds a post-processing transform that interprets this output:
+
+| Task | Post-processor | What It Does |
+|------|---------------|-------------|
+| Embeddings | `EmbeddingPoolingTransformer` | Mean/CLS/Max pooling + L2 normalization |
+| Classification | `SoftmaxClassificationTransformer` (planned) | Softmax over logits → class probabilities |
+| NER | `NerDecodingTransformer` (planned) | Per-token argmax → BIO entity spans |
+| Reranking | `SigmoidScorerTransformer` (planned) | Sigmoid on logit → relevance score |
+| QA | `QaSpanExtractionTransformer` (planned) | Start/end logit search → answer span |
+
 ## Lazy Evaluation via Custom IDataView / Cursor
 
 Each transform returns a **wrapping IDataView** from `Transform()` — no data is materialized. Computation happens lazily when a downstream consumer iterates via a cursor.
@@ -126,13 +161,6 @@ At any given moment, only **one batch** of intermediate data exists in memory (~
 ### Lookahead Batching (Scorer Only)
 
 The tokenizer and pooler are cheap (microseconds per row) — they process row-by-row. The ONNX scorer uses **lookahead batching**: it reads N rows from the upstream tokenizer cursor, packs them into a single ONNX batch, runs inference once, then serves cached results one at a time. This gives batch throughput with lazy memory semantics.
-
-### Two Faces: ML.NET + Direct
-
-Each transform exposes two faces:
-
-- **ML.NET face** (`Transform(IDataView)`): Lazy, wraps input. Used by ML.NET pipelines.
-- **Direct face** (`Tokenize()`, `Score()`, `Pool()`): Eager, processes batches directly. Used by `GenerateEmbeddings()` and `OnnxEmbeddingGenerator`.
 
 ## Estimator Lifecycle: What Happens in `Fit()`
 

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1,6 +1,6 @@
 # Design Decisions
 
-This document explains *why* every major design choice was made. It's written for developers and AI coding agents who need to understand the trade-off space before modifying or extending the solution.
+This document explains *why* every major design choice was made. It's written for developers and AI coding agents who need to understand the trade-off space before modifying or extending the `MLNet.TextInference.Onnx` solution.
 
 ## The ML.NET Constraint Landscape
 
@@ -261,7 +261,19 @@ The original monolithic `OnnxTextEmbeddingTransformer` bundled tokenization, ONN
 
 ### Why Keep the Facade?
 
-The `OnnxTextEmbeddingEstimator`/`OnnxTextEmbeddingTransformer` remain as a convenience facade that chains all three transforms internally. This preserves the existing public API (zero breaking changes) while allowing advanced users to compose the transforms directly.
+The `OnnxTextEmbeddingEstimator`/`OnnxTextEmbeddingTransformer` remain as a convenience facade that chains all three transforms internally. This preserves the existing public API (zero breaking changes) while allowing advanced users to compose the transforms directly. Future tasks (classification, NER, reranking, QA) will each get their own facade following the same pattern.
+
+## Why OnnxTextModelScorer Stays Generic
+
+The scorer is intentionally named `OnnxTextModelScorerTransformer`, not `OnnxTextEncoderScorerTransformer` or `OnnxEmbeddingScorerTransformer`. This is deliberate:
+
+1. **Task-agnostic by design**: The scorer runs *any* ONNX encoder model and outputs raw tensors. It has no knowledge of what the downstream task will be — embeddings, classification, NER, reranking, or QA. Naming it after a specific task or architecture would be misleading.
+
+2. **Shared across all tasks**: Every task in the platform (see the [task status table](../README.md)) shares the same scorer. Renaming it for one task would confuse the relationship with other tasks.
+
+3. **Encoder agnostic**: While the current focus is encoder transformers (BERT, RoBERTa, etc.), the scorer's contract is simply "take token columns, run ONNX, output raw tensors." This could theoretically work with non-encoder architectures that accept the same input format.
+
+4. **Convention over configuration**: The name reflects what the class *does* (scores text via an ONNX model) rather than what architecture it targets. This follows the ML.NET naming convention where transforms are named by their action, not their implementation detail.
 
 ### Lazy vs Eager Evaluation
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -2,11 +2,120 @@
 
 This document covers how to modify, extend, and harden the solution. Each section includes the specific files to change and the patterns to follow.
 
+## How to Add a New Task
+
+The platform is designed so that adding a new task (classification, NER, reranking, QA) requires only a few new files — the shared tokenizer and scorer are reused. Follow these steps:
+
+### Step 1: Create an options class
+
+Create a new file in the appropriate task subdirectory (e.g., `src/MLNet.TextInference.Onnx/Classification/`):
+
+```csharp
+namespace MLNet.TextInference.Onnx.Classification;
+
+public class SoftmaxClassificationOptions
+{
+    public string InputColumnName { get; set; } = "RawOutput";
+    public string ProbabilitiesColumnName { get; set; } = "Probabilities";
+    public string PredictedLabelColumnName { get; set; } = "PredictedLabel";
+    public string[]? Labels { get; set; }  // e.g., ["negative", "positive"]
+}
+```
+
+### Step 2: Create a post-processing estimator + transformer
+
+Follow the same pattern as `EmbeddingPoolingEstimator` / `EmbeddingPoolingTransformer`:
+
+- The **estimator** validates options and returns a fitted transformer
+- The **transformer** implements `ITransformer` with both ML.NET and direct faces:
+  - `Transform(IDataView)` — returns a lazy wrapping `IDataView`
+  - Internal batch method (e.g., `Classify()`) — eager, for the facade's direct path
+
+```csharp
+namespace MLNet.TextInference.Onnx.Classification;
+
+public class SoftmaxClassificationEstimator
+    : IEstimator<SoftmaxClassificationTransformer>
+{
+    public SoftmaxClassificationTransformer Fit(IDataView input) { ... }
+    public SchemaShape GetOutputSchema(SchemaShape inputSchema) { ... }
+}
+```
+
+The transformer reads the `RawOutput` column from the scorer, applies task-specific logic (softmax, argmax, BIO decoding, etc.), and outputs new columns.
+
+### Step 3: Create a facade estimator
+
+Create a convenience facade that chains tokenizer → scorer → your post-processor:
+
+```csharp
+namespace MLNet.TextInference.Onnx.Classification;
+
+public class OnnxTextClassificationEstimator
+    : IEstimator<OnnxTextClassificationTransformer>
+{
+    public OnnxTextClassificationEstimator(MLContext mlContext, OnnxTextClassificationOptions options) { ... }
+
+    public OnnxTextClassificationTransformer Fit(IDataView input)
+    {
+        // 1. Create and fit tokenizer
+        // 2. Create and fit scorer
+        // 3. Create and fit SoftmaxClassification post-processor
+        // 4. Return composite transformer
+    }
+}
+```
+
+### Step 4: Add extension methods to MLContextExtensions.cs
+
+Add fluent API extensions for both the post-processor and the facade:
+
+```csharp
+// Post-processor extension
+public static SoftmaxClassificationEstimator SoftmaxClassify(
+    this TransformsCatalog catalog, SoftmaxClassificationOptions options)
+{
+    return new SoftmaxClassificationEstimator(options);
+}
+
+// Facade extension
+public static OnnxTextClassificationEstimator OnnxTextClassification(
+    this TransformsCatalog catalog, OnnxTextClassificationOptions options)
+{
+    var mlContext = GetMLContext(catalog);
+    return new OnnxTextClassificationEstimator(mlContext, options);
+}
+```
+
+### Step 5: Create a sample
+
+Add a new sample directory (e.g., `samples/SentimentClassification/`) demonstrating both the composable pipeline and the facade:
+
+```csharp
+// Composable pipeline
+var pipeline = mlContext.Transforms.TokenizeText(tokOpts)
+    .Append(mlContext.Transforms.ScoreOnnxTextModel(scorerOpts))
+    .Append(mlContext.Transforms.SoftmaxClassify(classOpts));
+
+// Facade
+var estimator = mlContext.Transforms.OnnxTextClassification(options);
+```
+
+### Summary checklist for a new task
+
+- [ ] Options class in `src/MLNet.TextInference.Onnx/<Task>/`
+- [ ] Post-processing estimator + transformer
+- [ ] Facade estimator + transformer (chains tokenizer → scorer → post-processor)
+- [ ] Extension methods in `MLContextExtensions.cs`
+- [ ] Sample in `samples/`
+- [ ] Update the task status table in `README.md`
+- [ ] Update `docs/architecture.md` component map
+
 ## Adding New Pooling Strategies
 
-**File to modify:** `EmbeddingPooling.cs`
+**File to modify:** `src/MLNet.TextInference.Onnx/Embeddings/EmbeddingPooling.cs`
 
-1. Add a value to the `PoolingStrategy` enum in `PoolingStrategy.cs`:
+1. Add a value to the `PoolingStrategy` enum in `Embeddings/PoolingStrategy.cs`:
 
 ```csharp
 public enum PoolingStrategy
@@ -18,7 +127,7 @@ public enum PoolingStrategy
 }
 ```
 
-2. Add a private method and a case to the `Pool()` switch in `EmbeddingPooling.cs`:
+2. Add a private method and a case to the `Pool()` switch in `Embeddings/EmbeddingPooling.cs`:
 
 ```csharp
 PoolingStrategy.WeightedMeanPooling => WeightedMeanPool(
@@ -61,7 +170,7 @@ private static float[] WeightedMeanPool(
 
 ## Supporting New Tokenizer Formats
 
-**File to modify:** `TextTokenizerEstimator.cs` — `LoadTokenizer()` method
+**File to modify:** `src/MLNet.TextInference.Onnx/TextTokenizerEstimator.cs` — `LoadTokenizer()` method
 
 `LoadTokenizer()` uses smart resolution to handle directories, HuggingFace config files, and direct vocab files. It currently supports:
 
@@ -210,9 +319,14 @@ var pooled = pooler.Transform(scored);
 
 ## Adding New Post-Processing Transforms
 
-The composable architecture makes it easy to add new task-specific transforms that consume the scorer's raw output:
+The composable architecture makes it easy to add new task-specific transforms that consume the scorer's raw output. See [How to Add a New Task](#how-to-add-a-new-task) above for the full step-by-step guide.
 
 ```csharp
+// Embeddings (implemented)
+var pipeline = mlContext.Transforms.TokenizeText(tokOpts)
+    .Append(mlContext.Transforms.ScoreOnnxTextModel(scorerOpts))
+    .Append(mlContext.Transforms.PoolEmbedding(poolingOpts));
+
 // Future: text classification
 var pipeline = mlContext.Transforms.TokenizeText(tokOpts)
     .Append(mlContext.Transforms.ScoreOnnxTextModel(scorerOpts))

--- a/docs/modular-pipeline-changes.md
+++ b/docs/modular-pipeline-changes.md
@@ -64,7 +64,7 @@ The original monolithic API still works — `OnnxTextEmbeddingEstimator` is now 
 ### Code shape (main)
 
 ```
-src/MLNet.Embeddings.Onnx/
+src/MLNet.TextInference.Onnx/
 ├── OnnxTextEmbeddingEstimator.cs    (158 lines — loads model, tokenizer, discovers metadata)
 ├── OnnxTextEmbeddingTransformer.cs  (222 lines — tokenize + infer + pool + normalize)
 ├── OnnxTextEmbeddingOptions.cs      (configuration)
@@ -133,21 +133,22 @@ src/MLNet.Embeddings.Onnx/
 ### Code shape (proposals/modular-transforms)
 
 ```
-src/MLNet.Embeddings.Onnx/
+src/MLNet.TextInference.Onnx/
 ├── TextTokenizerEstimator.cs           (239 lines — NEW: smart tokenizer resolution)
 ├── TextTokenizerTransformer.cs         (235 lines — NEW: BPE/WordPiece/SentencePiece)
 ├── OnnxTextModelScorerEstimator.cs     (168 lines — NEW: ONNX metadata discovery)
 ├── OnnxTextModelScorerTransformer.cs   (410 lines — NEW: lookahead batching, lazy cursor)
-├── EmbeddingPoolingEstimator.cs        (95 lines  — NEW: pooling configuration)
-├── EmbeddingPoolingTransformer.cs      (223 lines — NEW: Mean/CLS/Max + normalize)
-├── OnnxTextEmbeddingEstimator.cs       (105 lines — REFACTORED: now chains 3 transforms)
-├── OnnxTextEmbeddingTransformer.cs     (99 lines  — REFACTORED: delegates to 3 sub-transforms)
-├── EmbeddingGeneratorEstimator.cs      (151 lines — NEW: provider-agnostic MEAI wrapper)
-├── OnnxEmbeddingGenerator.cs           (unchanged — MEAI IEmbeddingGenerator)
+├── Embeddings/
+│   ├── EmbeddingPoolingEstimator.cs    (95 lines  — NEW: pooling configuration)
+│   ├── EmbeddingPoolingTransformer.cs  (223 lines — NEW: Mean/CLS/Max + normalize)
+│   ├── OnnxTextEmbeddingEstimator.cs   (105 lines — REFACTORED: now chains 3 transforms)
+│   ├── OnnxTextEmbeddingTransformer.cs (99 lines  — REFACTORED: delegates to 3 sub-transforms)
+│   ├── EmbeddingGeneratorEstimator.cs  (151 lines — NEW: provider-agnostic MEAI wrapper)
+│   ├── OnnxEmbeddingGenerator.cs       (unchanged — MEAI IEmbeddingGenerator)
+│   ├── EmbeddingPooling.cs             (unchanged — SIMD pooling math)
+│   ├── ModelPackager.cs                (unchanged — zip save/load)
+│   └── OnnxTextEmbeddingOptions.cs     (minor changes)
 ├── MLContextExtensions.cs              (64 lines  — EXPANDED: 5 extension methods)
-├── EmbeddingPooling.cs                 (unchanged — SIMD pooling math)
-├── ModelPackager.cs                    (unchanged — zip save/load)
-├── OnnxTextEmbeddingOptions.cs         (minor changes)
 └── PoolingStrategy.cs                  (unchanged)
 ```
 

--- a/proposals/01-text-tokenizer-transform.md
+++ b/proposals/01-text-tokenizer-transform.md
@@ -8,13 +8,13 @@ Tokenizes text into token IDs, attention masks, and token type IDs suitable for 
 
 | File | Contents |
 |------|----------|
-| `src/MLNet.Embeddings.Onnx/TextTokenizerEstimator.cs` | Estimator + options class |
-| `src/MLNet.Embeddings.Onnx/TextTokenizerTransformer.cs` | Transformer |
+| `src/MLNet.TextInference.Onnx/TextTokenizerEstimator.cs` | Estimator + options class |
+| `src/MLNet.TextInference.Onnx/TextTokenizerTransformer.cs` | Transformer |
 
 ## Options Class
 
 ```csharp
-namespace MLNet.Embeddings.Onnx;
+namespace MLNet.TextInference.Onnx;
 
 /// <summary>
 /// Configuration for the text tokenizer transform.
@@ -72,7 +72,7 @@ public class TextTokenizerOptions
 ## Estimator
 
 ```csharp
-namespace MLNet.Embeddings.Onnx;
+namespace MLNet.TextInference.Onnx;
 
 /// <summary>
 /// ML.NET IEstimator that creates a TextTokenizerTransformer.
@@ -168,7 +168,7 @@ public sealed class TextTokenizerEstimator : IEstimator<TextTokenizerTransformer
 ## Transformer
 
 ```csharp
-namespace MLNet.Embeddings.Onnx;
+namespace MLNet.TextInference.Onnx;
 
 /// <summary>
 /// ML.NET ITransformer that tokenizes text into token IDs, attention masks,

--- a/proposals/02-onnx-text-model-scorer-transform.md
+++ b/proposals/02-onnx-text-model-scorer-transform.md
@@ -14,13 +14,13 @@ Runs ONNX inference on tokenized text inputs. This is the **universal second ste
 
 | File | Contents |
 |------|----------|
-| `src/MLNet.Embeddings.Onnx/OnnxTextModelScorerEstimator.cs` | Estimator + options class |
-| `src/MLNet.Embeddings.Onnx/OnnxTextModelScorerTransformer.cs` | Transformer |
+| `src/MLNet.TextInference.Onnx/OnnxTextModelScorerEstimator.cs` | Estimator + options class |
+| `src/MLNet.TextInference.Onnx/OnnxTextModelScorerTransformer.cs` | Transformer |
 
 ## Options Class
 
 ```csharp
-namespace MLNet.Embeddings.Onnx;
+namespace MLNet.TextInference.Onnx;
 
 /// <summary>
 /// Configuration for the ONNX text model scorer transform.
@@ -92,7 +92,7 @@ This separation is important because column names are a pipeline concern (how tr
 ## Estimator
 
 ```csharp
-namespace MLNet.Embeddings.Onnx;
+namespace MLNet.TextInference.Onnx;
 
 /// <summary>
 /// ML.NET IEstimator that creates an OnnxTextModelScorerTransformer.
@@ -216,7 +216,7 @@ internal sealed record OnnxModelMetadata(
 ## Transformer
 
 ```csharp
-namespace MLNet.Embeddings.Onnx;
+namespace MLNet.TextInference.Onnx;
 
 /// <summary>
 /// ML.NET ITransformer that runs ONNX inference on tokenized text inputs.

--- a/proposals/03-embedding-pooling-transform.md
+++ b/proposals/03-embedding-pooling-transform.md
@@ -15,13 +15,13 @@ Applies pooling and normalization to raw model output to produce a fixed-length 
 
 | File | Contents |
 |------|----------|
-| `src/MLNet.Embeddings.Onnx/EmbeddingPoolingEstimator.cs` | Estimator + options class |
-| `src/MLNet.Embeddings.Onnx/EmbeddingPoolingTransformer.cs` | Transformer |
+| `src/MLNet.TextInference.Onnx/EmbeddingPoolingEstimator.cs` | Estimator + options class |
+| `src/MLNet.TextInference.Onnx/EmbeddingPoolingTransformer.cs` | Transformer |
 
 ## Options Class
 
 ```csharp
-namespace MLNet.Embeddings.Onnx;
+namespace MLNet.TextInference.Onnx;
 
 /// <summary>
 /// Configuration for the embedding pooling transform.
@@ -83,7 +83,7 @@ public class EmbeddingPoolingOptions
 ## Estimator
 
 ```csharp
-namespace MLNet.Embeddings.Onnx;
+namespace MLNet.TextInference.Onnx;
 
 /// <summary>
 /// ML.NET IEstimator that creates an EmbeddingPoolingTransformer.
@@ -177,7 +177,7 @@ public sealed class EmbeddingPoolingEstimator : IEstimator<EmbeddingPoolingTrans
 ## Transformer
 
 ```csharp
-namespace MLNet.Embeddings.Onnx;
+namespace MLNet.TextInference.Onnx;
 
 /// <summary>
 /// ML.NET ITransformer that pools raw model output into fixed-length embeddings.

--- a/proposals/04-facade-refactor.md
+++ b/proposals/04-facade-refactor.md
@@ -8,9 +8,9 @@ Refactor the existing `OnnxTextEmbeddingEstimator` and `OnnxTextEmbeddingTransfo
 
 | File | Change Type |
 |------|-------------|
-| `src/MLNet.Embeddings.Onnx/OnnxTextEmbeddingEstimator.cs` | Major refactor |
-| `src/MLNet.Embeddings.Onnx/OnnxTextEmbeddingTransformer.cs` | Major refactor |
-| `src/MLNet.Embeddings.Onnx/OnnxTextEmbeddingOptions.cs` | Unchanged |
+| `src/MLNet.TextInference.Onnx/OnnxTextEmbeddingEstimator.cs` | Major refactor |
+| `src/MLNet.TextInference.Onnx/OnnxTextEmbeddingTransformer.cs` | Major refactor |
+| `src/MLNet.TextInference.Onnx/OnnxTextEmbeddingOptions.cs` | Unchanged |
 
 ## What Stays the Same
 
@@ -25,7 +25,7 @@ Refactor the existing `OnnxTextEmbeddingEstimator` and `OnnxTextEmbeddingTransfo
 ## Refactored Estimator
 
 ```csharp
-namespace MLNet.Embeddings.Onnx;
+namespace MLNet.TextInference.Onnx;
 
 /// <summary>
 /// ML.NET IEstimator that creates an OnnxTextEmbeddingTransformer.
@@ -117,7 +117,7 @@ public sealed class OnnxTextEmbeddingEstimator : IEstimator<OnnxTextEmbeddingTra
 ## Refactored Transformer
 
 ```csharp
-namespace MLNet.Embeddings.Onnx;
+namespace MLNet.TextInference.Onnx;
 
 /// <summary>
 /// ML.NET ITransformer that generates text embeddings using a local ONNX model.

--- a/proposals/05-meai-integration.md
+++ b/proposals/05-meai-integration.md
@@ -40,21 +40,21 @@ These are complementary, not competing:
 
 | File | Contents |
 |------|----------|
-| `src/MLNet.Embeddings.Onnx/EmbeddingGeneratorEstimator.cs` | Estimator + transformer + options |
+| `src/MLNet.TextInference.Onnx/EmbeddingGeneratorEstimator.cs` | Estimator + transformer + options |
 
 ## Files to Modify
 
 | File | Change |
 |------|--------|
-| `src/MLNet.Embeddings.Onnx/OnnxEmbeddingGenerator.cs` | Refactor to use sub-transform direct faces |
-| `src/MLNet.Embeddings.Onnx/MLContextExtensions.cs` | Add extension method |
+| `src/MLNet.TextInference.Onnx/OnnxEmbeddingGenerator.cs` | Refactor to use sub-transform direct faces |
+| `src/MLNet.TextInference.Onnx/MLContextExtensions.cs` | Add extension method |
 
 ## EmbeddingGeneratorEstimator
 
 ### Options
 
 ```csharp
-namespace MLNet.Embeddings.Onnx;
+namespace MLNet.TextInference.Onnx;
 
 /// <summary>
 /// Configuration for the provider-agnostic embedding generator transform.
@@ -78,7 +78,7 @@ public class EmbeddingGeneratorOptions
 ### Estimator
 
 ```csharp
-namespace MLNet.Embeddings.Onnx;
+namespace MLNet.TextInference.Onnx;
 
 /// <summary>
 /// ML.NET IEstimator that wraps any IEmbeddingGenerator to produce embeddings within a pipeline.
@@ -133,7 +133,7 @@ The `EmbeddingGeneratorTransformer` uses **eager evaluation** (not the lazy IDat
 - For ONNX specifically, users should prefer the three-way composable pipeline for lazy evaluation
 
 ```csharp
-namespace MLNet.Embeddings.Onnx;
+namespace MLNet.TextInference.Onnx;
 
 /// <summary>
 /// ML.NET ITransformer that generates embeddings using any IEmbeddingGenerator.

--- a/proposals/06-post-modularization-samples.md
+++ b/proposals/06-post-modularization-samples.md
@@ -27,7 +27,7 @@ After the modular transform pipeline (proposals 01–05) merges, add samples tha
 ```csharp
 using System.Numerics.Tensors;
 using Microsoft.ML;
-using MLNet.Embeddings.Onnx;
+using MLNet.TextInference.Onnx;
 
 var modelPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "models", "model.onnx"));
 var tokenizerPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "models")); // directory — auto-detects from tokenizer_config.json or known vocab files
@@ -131,7 +131,7 @@ public class EmbeddingResult { public string Text { get; set; } = ""; public flo
 
 ```csharp
 using Microsoft.ML;
-using MLNet.Embeddings.Onnx;
+using MLNet.TextInference.Onnx;
 
 var modelPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "models", "model.onnx"));
 var tokenizerPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "models")); // directory — auto-detects tokenizer
@@ -265,7 +265,7 @@ public class EmbeddingResult { public string Text { get; set; } = ""; public flo
 using System.Numerics.Tensors;
 using Microsoft.Extensions.AI;
 using Microsoft.ML;
-using MLNet.Embeddings.Onnx;
+using MLNet.TextInference.Onnx;
 
 var modelPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "models", "model.onnx"));
 var tokenizerPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "models")); // directory — auto-detects tokenizer

--- a/proposals/future-tasks.md
+++ b/proposals/future-tasks.md
@@ -2,21 +2,32 @@
 
 ## The Platform Vision
 
-The three-way split creates a reusable foundation for ANY transformer-based ONNX model task in ML.NET. The tokenizer and scorer are shared; only the post-processing varies by task.
+The `MLNet.TextInference.Onnx` platform provides a reusable foundation for ANY transformer-based ONNX model task in ML.NET. The tokenizer and scorer are shared; only the post-processing varies by task.
 
 ```
                     TextTokenizerTransformer
                             │
                             ▼
-                 OnnxTextModelScorerTransformer
+                 OnnxTextModelScorerTransformer       (task-agnostic)
                             │
-            ┌───────────────┼───────────────────────────┐
-            │               │               │           │
-            ▼               ▼               ▼           ▼
-     EmbeddingPooling  SoftmaxClassify  NerDecoding  CrossEncoder
-     Transformer       Transformer      Transformer  Transformer
-     (exists)          (future)         (future)     (future)
+            ┌───────────────┼────────────────┐
+            │               │                │
+     EmbeddingPooling  SoftmaxClassify  (more tasks)
+     Transformer       Transformer      coming soon
 ```
+
+## Current Task Status
+
+| Task | Status | Post-processor | Facade |
+|------|--------|---------------|--------|
+| Embeddings | ✅ Implemented | `EmbeddingPoolingTransformer` | `OnnxTextEmbeddingEstimator` |
+| Classification | 🔲 Planned | `SoftmaxClassificationTransformer` | `OnnxTextClassificationEstimator` |
+| Reranking | 🔲 Planned | `SigmoidScorerTransformer` | `OnnxRerankerEstimator` |
+| NER | 🔲 Planned | `NerDecodingTransformer` | `OnnxNerEstimator` |
+| QA | 🔲 Planned | `QaSpanExtractionTransformer` | `OnnxQaEstimator` |
+| Text Generation | 🔲 Planned | `ChatClientTransformer` | N/A |
+
+For the step-by-step guide on adding a new task, see [docs/extending.md](../docs/extending.md#how-to-add-a-new-task).
 
 ## Task: Text Classification
 

--- a/proposals/implementation-plan.md
+++ b/proposals/implementation-plan.md
@@ -48,8 +48,8 @@ build-test
 ### Files to Create
 | File | Lines (est.) |
 |------|-------------|
-| `src/MLNet.Embeddings.Onnx/TextTokenizerEstimator.cs` | ~120 |
-| `src/MLNet.Embeddings.Onnx/TextTokenizerTransformer.cs` | ~300 (includes TokenizerDataView + TokenizerCursor) |
+| `src/MLNet.TextInference.Onnx/TextTokenizerEstimator.cs` | ~120 |
+| `src/MLNet.TextInference.Onnx/TextTokenizerTransformer.cs` | ~300 (includes TokenizerDataView + TokenizerCursor) |
 
 ### Code to Extract From
 - `OnnxTextEmbeddingEstimator.LoadTokenizer()` → `TextTokenizerEstimator.LoadTokenizer()` (expanded with smart resolution: directory, config, vocab file)
@@ -85,8 +85,8 @@ build-test
 ### Files to Create
 | File | Lines (est.) |
 |------|-------------|
-| `src/MLNet.Embeddings.Onnx/OnnxTextModelScorerEstimator.cs` | ~140 |
-| `src/MLNet.Embeddings.Onnx/OnnxTextModelScorerTransformer.cs` | ~450 (includes ScorerDataView + ScorerCursor with lookahead batching) |
+| `src/MLNet.TextInference.Onnx/OnnxTextModelScorerEstimator.cs` | ~140 |
+| `src/MLNet.TextInference.Onnx/OnnxTextModelScorerTransformer.cs` | ~450 (includes ScorerDataView + ScorerCursor with lookahead batching) |
 
 ### Code to Extract From
 - `OnnxTextEmbeddingEstimator.DiscoverModelMetadata()` → `OnnxTextModelScorerEstimator.DiscoverModelMetadata()`
@@ -125,8 +125,8 @@ build-test
 ### Files to Create
 | File | Lines (est.) |
 |------|-------------|
-| `src/MLNet.Embeddings.Onnx/EmbeddingPoolingEstimator.cs` | ~100 |
-| `src/MLNet.Embeddings.Onnx/EmbeddingPoolingTransformer.cs` | ~280 (includes PoolerDataView + PoolerCursor) |
+| `src/MLNet.TextInference.Onnx/EmbeddingPoolingEstimator.cs` | ~100 |
+| `src/MLNet.TextInference.Onnx/EmbeddingPoolingTransformer.cs` | ~280 (includes PoolerDataView + PoolerCursor) |
 
 ### Code to Extract From
 - `OnnxTextEmbeddingTransformer.ProcessBatch()` lines 173-183 → `EmbeddingPoolingTransformer.Pool()` (direct face) and `PoolerCursor.MoveNext()`
@@ -166,7 +166,7 @@ build-test
 ### Files to Modify
 | File | Change |
 |------|--------|
-| `src/MLNet.Embeddings.Onnx/OnnxTextEmbeddingEstimator.cs` | Major refactor: compose 3 sub-transforms |
+| `src/MLNet.TextInference.Onnx/OnnxTextEmbeddingEstimator.cs` | Major refactor: compose 3 sub-transforms |
 
 ### What Changes
 - `Fit()` creates and chains TokenizerEstimator → ScorerEstimator → PoolingEstimator
@@ -196,7 +196,7 @@ build-test
 ### Files to Modify
 | File | Change |
 |------|--------|
-| `src/MLNet.Embeddings.Onnx/OnnxTextEmbeddingTransformer.cs` | Major refactor: wrap 3 sub-transformers |
+| `src/MLNet.TextInference.Onnx/OnnxTextEmbeddingTransformer.cs` | Major refactor: wrap 3 sub-transformers |
 
 ### What Changes
 - Fields: replace `_session`, `_tokenizer`, tensor names → `_tokenizer`, `_scorer`, `_pooler` sub-transforms
@@ -238,7 +238,7 @@ build-test
 ### Files to Modify
 | File | Change |
 |------|--------|
-| `src/MLNet.Embeddings.Onnx/MLContextExtensions.cs` | Add extension methods |
+| `src/MLNet.TextInference.Onnx/MLContextExtensions.cs` | Add extension methods |
 
 ### New Extension Methods
 - `mlContext.Transforms.TokenizeText(options)` → `TextTokenizerEstimator`
@@ -260,7 +260,7 @@ build-test
 ### Files to Modify
 | File | Change |
 |------|--------|
-| `src/MLNet.Embeddings.Onnx/ModelPackager.cs` | Access sub-transform state via new structure |
+| `src/MLNet.TextInference.Onnx/ModelPackager.cs` | Access sub-transform state via new structure |
 
 ### What Changes
 - `Save()`: access model path via `transformer.Scorer.Options.ModelPath` (or keep via `transformer.Options`)
@@ -286,12 +286,12 @@ If `OnnxTextEmbeddingTransformer` still exposes `Options` (the original `OnnxTex
 ### Files to Create
 | File | Lines (est.) |
 |------|-------------|
-| `src/MLNet.Embeddings.Onnx/EmbeddingGeneratorEstimator.cs` | ~120 |
+| `src/MLNet.TextInference.Onnx/EmbeddingGeneratorEstimator.cs` | ~120 |
 
 ### Files to Modify
 | File | Change |
 |------|--------|
-| `src/MLNet.Embeddings.Onnx/MLContextExtensions.cs` | Add `TextEmbedding(generator)` extension |
+| `src/MLNet.TextInference.Onnx/MLContextExtensions.cs` | Add `TextEmbedding(generator)` extension |
 
 ### Files NOT Modified
 - `OnnxEmbeddingGenerator.cs` — unchanged (benefits automatically from facade refactor)


### PR DESCRIPTION
Update all documentation to reflect the multi-task text inference platform:

- Rewrite README.md with architecture diagram, task status table, and platform vision
- Update docs/architecture.md with shared foundation explanation
- Update docs/design-decisions.md with generic scorer rationale
- Add 'how to add a new task' guide to docs/extending.md
- Update all proposals/ references to new namespace

Depends on #10 (rename) and #9 (ADR).
Closes #7