### PR TITLE
feat: Text generation transforms (ChatClient + ORT GenAI)

### DIFF
--- a/MLNet.TextInference.Onnx.slnx
+++ b/MLNet.TextInference.Onnx.slnx
@@ -10,8 +10,11 @@
     <Project Path="samples/Classification/SentimentDistilBERT/SentimentDistilBERT.csproj" />
     <Project Path="samples/Classification/EmotionRoBERTa/EmotionRoBERTa.csproj" />
     <Project Path="samples/Classification/ZeroShotDeBERTa/ZeroShotDeBERTa.csproj" />
+    <Project Path="samples/TextGenerationMeai/TextGenerationMeai.csproj" />
+    <Project Path="samples/TextGenerationLocal/TextGenerationLocal.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/MLNet.TextInference.Onnx/MLNet.TextInference.Onnx.csproj" />
+    <Project Path="src/MLNet.TextGeneration.OnnxGenAI/MLNet.TextGeneration.OnnxGenAI.csproj" />
   </Folder>
 </Solution>

--- a/samples/TextGenerationLocal/Program.cs
+++ b/samples/TextGenerationLocal/Program.cs
@@ -1,0 +1,84 @@
+using Microsoft.ML;
+using MLNet.TextGeneration.OnnxGenAI;
+
+Console.WriteLine("=== Local ONNX Text Generation ===\n");
+Console.WriteLine("Use OnnxTextGenerationEstimator for local text generation with ONNX Runtime GenAI.\n");
+
+// --- Configuration ---
+// Download a model first (see README.md for instructions).
+var modelPath = args.Length > 0
+    ? args[0]
+    : Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "models", "phi-3-mini"));
+
+if (!Directory.Exists(modelPath))
+{
+    Console.WriteLine($"Model not found at: {modelPath}");
+    Console.WriteLine("Please download a model first. See README.md for instructions.");
+    Console.WriteLine("\nUsage: dotnet run [model-path]");
+    return;
+}
+
+var mlContext = new MLContext();
+
+var options = new OnnxTextGenerationOptions
+{
+    ModelPath = modelPath,
+    MaxLength = 256,
+    Temperature = 0.7f,
+    TopP = 0.9f,
+    SystemPrompt = "You are a helpful assistant. Be concise."
+};
+
+// --- ML.NET Pipeline ---
+Console.WriteLine("1. ML.NET Pipeline with OnnxTextGenerationEstimator");
+Console.WriteLine(new string('-', 55));
+
+var sampleData = new[]
+{
+    new TextData { Text = "What is machine learning?" },
+    new TextData { Text = "Explain .NET in one sentence." },
+};
+
+var dataView = mlContext.Data.LoadFromEnumerable(sampleData);
+var estimator = mlContext.Transforms.OnnxTextGeneration(options);
+var transformer = estimator.Fit(dataView);
+var transformed = transformer.Transform(dataView);
+
+var results = mlContext.Data.CreateEnumerable<TextGenerationResult>(transformed, reuseRowObject: false).ToList();
+
+foreach (var (item, idx) in results.Select((r, i) => (r, i)))
+{
+    Console.WriteLine($"  Prompt:   \"{sampleData[idx].Text}\"");
+    Console.WriteLine($"  Response: \"{item.GeneratedText}\"");
+    Console.WriteLine();
+}
+
+// --- Direct Generate() API ---
+Console.WriteLine("2. Direct Generate() API");
+Console.WriteLine(new string('-', 55));
+
+var prompts = new[] { "What is 2+2?", "Name three colors." };
+var responses = transformer.Generate(prompts);
+
+for (int i = 0; i < prompts.Length; i++)
+{
+    Console.WriteLine($"  Prompt:   \"{prompts[i]}\"");
+    Console.WriteLine($"  Response: \"{responses[i]}\"");
+    Console.WriteLine();
+}
+
+// Cleanup
+transformer.Dispose();
+Console.WriteLine("Done!");
+
+// --- Domain types ---
+public class TextData
+{
+    public string Text { get; set; } = "";
+}
+
+public class TextGenerationResult
+{
+    public string Text { get; set; } = "";
+    public string GeneratedText { get; set; } = "";
+}

--- a/samples/TextGenerationLocal/README.md
+++ b/samples/TextGenerationLocal/README.md
@@ -1,0 +1,58 @@
+# TextGenerationLocal Sample
+
+Use `OnnxTextGenerationEstimator` for **local text generation** with ONNX Runtime GenAI — no cloud APIs required.
+
+## Model Download
+
+This sample requires a local ONNX GenAI model. We recommend [Phi-3-mini-4k-instruct](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-onnx).
+
+### Using Hugging Face CLI
+
+```bash
+pip install huggingface-hub
+huggingface-cli download microsoft/Phi-3-mini-4k-instruct-onnx --include "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/*" --local-dir models/phi-3-mini
+```
+
+### Manual Download
+
+1. Visit [microsoft/Phi-3-mini-4k-instruct-onnx](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-onnx)
+2. Download the `cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4` variant
+3. Place all files in `models/phi-3-mini/`
+
+## Run
+
+```bash
+# Default model path (models/phi-3-mini)
+dotnet run
+
+# Custom model path
+dotnet run -- /path/to/your/model
+```
+
+## What This Sample Shows
+
+1. **ML.NET Pipeline** — `OnnxTextGenerationEstimator` as a standard ML.NET transform with local ONNX inference
+2. **Direct API** — Use `OnnxTextGenerationTransformer.Generate()` directly without IDataView overhead
+3. **Prompt Formatting** — Automatic chat template formatting with system prompt support
+
+## Key Code Pattern
+
+```csharp
+var options = new OnnxTextGenerationOptions
+{
+    ModelPath = "/path/to/model",
+    MaxLength = 256,
+    Temperature = 0.7f,
+    SystemPrompt = "You are a helpful assistant."
+};
+
+var estimator = mlContext.Transforms.OnnxTextGeneration(options);
+var transformer = estimator.Fit(dataView);
+var results = transformer.Transform(dataView);
+
+// Or use directly
+var responses = transformer.Generate(new[] { "What is ML.NET?" });
+
+// Don't forget to dispose (owns the ONNX model)
+transformer.Dispose();
+```

--- a/samples/TextGenerationLocal/TextGenerationLocal.csproj
+++ b/samples/TextGenerationLocal/TextGenerationLocal.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MLNet.TextGeneration.OnnxGenAI\MLNet.TextGeneration.OnnxGenAI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/TextGenerationMeai/Program.cs
+++ b/samples/TextGenerationMeai/Program.cs
@@ -1,0 +1,106 @@
+using Microsoft.Extensions.AI;
+using Microsoft.ML;
+using MLNet.TextInference.Onnx;
+
+Console.WriteLine("=== Provider-Agnostic Text Generation Transform ===\n");
+Console.WriteLine("Use ChatClientEstimator to wrap any IChatClient as an ML.NET transform.");
+Console.WriteLine("Swap DemoChatClient for OpenAI, Ollama, Azure OpenAI, ORT GenAI, etc.\n");
+
+var mlContext = new MLContext();
+
+// --- Create an IChatClient (demo/placeholder in this case) ---
+// This is the ONLY part that changes per provider.
+// For OpenAI:   new OpenAIClient(apiKey).GetChatClient("gpt-4o").AsIChatClient()
+// For Azure:    new AzureOpenAIClient(endpoint, credential).GetChatClient("gpt-4o").AsIChatClient()
+// For Ollama:   new OllamaChatClient(new Uri("http://localhost:11434"), "phi3")
+
+IChatClient chatClient = new DemoChatClient();
+
+// --- Use the chat client as an ML.NET transform ---
+Console.WriteLine("1. ML.NET Pipeline with ChatClientEstimator");
+Console.WriteLine(new string('-', 50));
+
+var estimator = mlContext.Transforms.TextGeneration(chatClient, new TextGenerationOptions
+{
+    SystemPrompt = "You are a helpful assistant. Be concise.",
+    MaxOutputTokens = 100,
+    Temperature = 0.7f
+});
+
+var sampleData = new[]
+{
+    new TextData { Text = "What is machine learning?" },
+    new TextData { Text = "Explain .NET in one sentence." },
+    new TextData { Text = "What is the capital of France?" }
+};
+
+var dataView = mlContext.Data.LoadFromEnumerable(sampleData);
+var transformer = estimator.Fit(dataView);
+var transformed = transformer.Transform(dataView);
+
+var results = mlContext.Data.CreateEnumerable<TextGenerationResult>(transformed, reuseRowObject: false).ToList();
+
+foreach (var (item, idx) in results.Select((r, i) => (r, i)))
+{
+    Console.WriteLine($"  Prompt:   \"{sampleData[idx].Text}\"");
+    Console.WriteLine($"  Response: \"{item.GeneratedText}\"");
+    Console.WriteLine();
+}
+
+// --- Direct Generate() API ---
+Console.WriteLine("2. Direct Generate() API");
+Console.WriteLine(new string('-', 50));
+
+var prompts = new[] { "What is 2+2?", "Name three colors." };
+var responses = transformer.Generate(prompts);
+
+for (int i = 0; i < prompts.Length; i++)
+{
+    Console.WriteLine($"  Prompt:   \"{prompts[i]}\"");
+    Console.WriteLine($"  Response: \"{responses[i]}\"");
+    Console.WriteLine();
+}
+
+Console.WriteLine("Note: Swap DemoChatClient for any IChatClient — pipeline code stays identical.");
+Console.WriteLine("\nDone!");
+
+// --- Domain types ---
+public class TextData
+{
+    public string Text { get; set; } = "";
+}
+
+public class TextGenerationResult
+{
+    public string Text { get; set; } = "";
+    public string GeneratedText { get; set; } = "";
+}
+
+/// <summary>
+/// A simple demo IChatClient that returns placeholder responses.
+/// Replace with a real provider (OpenAI, Ollama, Azure, ORT GenAI) for actual generation.
+/// </summary>
+public class DemoChatClient : IChatClient
+{
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var userMessage = messages.LastOrDefault(m => m.Role == ChatRole.User)?.Text ?? "";
+        var reply = $"[Demo response to: {userMessage}]";
+        return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, reply)));
+    }
+
+    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException("Streaming not supported in demo client.");
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+    public void Dispose() { }
+}

--- a/samples/TextGenerationMeai/README.md
+++ b/samples/TextGenerationMeai/README.md
@@ -1,0 +1,54 @@
+# TextGenerationMeai Sample
+
+Use `ChatClientEstimator` to wrap **any** `IChatClient` as an ML.NET transform — demonstrating **provider-agnostic** text generation.
+
+## What This Sample Shows
+
+1. **ML.NET Pipeline** — `ChatClientEstimator` wraps any `IChatClient` as a standard ML.NET transform
+2. **Direct API** — Use `ChatClientTransformer.Generate()` directly without IDataView overhead
+3. **Provider Swap** — Only the `IChatClient` construction changes per provider
+
+### The Provider-Agnostic Pattern
+
+```csharp
+// --- OpenAI ---
+IChatClient chatClient = new OpenAIClient(apiKey).GetChatClient("gpt-4o").AsIChatClient();
+
+// --- Ollama ---
+// IChatClient chatClient = new OllamaChatClient(new Uri("http://localhost:11434"), "phi3");
+
+// --- Azure OpenAI ---
+// IChatClient chatClient = new AzureOpenAIClient(endpoint, credential).GetChatClient("gpt-4o").AsIChatClient();
+
+// Pipeline code is IDENTICAL regardless of provider
+var estimator = mlContext.Transforms.TextGeneration(chatClient, new TextGenerationOptions
+{
+    SystemPrompt = "You are a helpful assistant.",
+    MaxOutputTokens = 100
+});
+var transformer = estimator.Fit(dataView);
+var results = transformer.Transform(dataView);
+```
+
+## Run
+
+```bash
+dotnet run
+```
+
+> **Note:** This sample uses a `DemoChatClient` that returns placeholder responses. Replace it with a real `IChatClient` provider for actual text generation.
+
+## Key Code Pattern
+
+```csharp
+// Create any IChatClient (provider-specific)
+IChatClient chatClient = ...;
+
+// Wrap as ML.NET transform (provider-agnostic)
+var estimator = mlContext.Transforms.TextGeneration(chatClient);
+var transformer = estimator.Fit(dataView);
+var results = transformer.Transform(dataView);
+
+// Or use directly
+var responses = transformer.Generate(new[] { "What is ML.NET?" });
+```

--- a/samples/TextGenerationMeai/TextGenerationMeai.csproj
+++ b/samples/TextGenerationMeai/TextGenerationMeai.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MLNet.TextInference.Onnx\MLNet.TextInference.Onnx.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/MLNet.TextGeneration.OnnxGenAI/MLContextExtensions.cs
+++ b/src/MLNet.TextGeneration.OnnxGenAI/MLContextExtensions.cs
@@ -1,0 +1,28 @@
+using Microsoft.ML;
+
+namespace MLNet.TextGeneration.OnnxGenAI;
+
+/// <summary>
+/// Extension methods for MLContext to provide a convenient API for ONNX GenAI text generation.
+/// </summary>
+public static class MLContextExtensions
+{
+    /// <summary>
+    /// Creates an estimator that generates text using a local ONNX Runtime GenAI model.
+    /// </summary>
+    public static OnnxTextGenerationEstimator OnnxTextGeneration(
+        this TransformsCatalog catalog,
+        OnnxTextGenerationOptions options)
+    {
+        return new OnnxTextGenerationEstimator(GetMLContext(catalog), options);
+    }
+
+    private static MLContext GetMLContext(TransformsCatalog catalog)
+    {
+        var envProperty = typeof(TransformsCatalog)
+            .GetProperty("Environment", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        if (envProperty?.GetValue(catalog) is MLContext mlContext)
+            return mlContext;
+        return new MLContext();
+    }
+}

--- a/src/MLNet.TextGeneration.OnnxGenAI/MLNet.TextGeneration.OnnxGenAI.csproj
+++ b/src/MLNet.TextGeneration.OnnxGenAI/MLNet.TextGeneration.OnnxGenAI.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ML" Version="5.0.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.7.1" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/MLNet.TextGeneration.OnnxGenAI/OnnxTextGenerationEstimator.cs
+++ b/src/MLNet.TextGeneration.OnnxGenAI/OnnxTextGenerationEstimator.cs
@@ -1,0 +1,55 @@
+using Microsoft.ML;
+using Microsoft.ML.Data;
+using Microsoft.ML.OnnxRuntimeGenAI;
+
+namespace MLNet.TextGeneration.OnnxGenAI;
+
+/// <summary>
+/// ML.NET IEstimator that loads an ONNX Runtime GenAI model for text generation.
+/// </summary>
+public sealed class OnnxTextGenerationEstimator : IEstimator<OnnxTextGenerationTransformer>
+{
+    private readonly MLContext _mlContext;
+    private readonly OnnxTextGenerationOptions _options;
+
+    public OnnxTextGenerationEstimator(MLContext mlContext, OnnxTextGenerationOptions options)
+    {
+        _mlContext = mlContext ?? throw new ArgumentNullException(nameof(mlContext));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public OnnxTextGenerationTransformer Fit(IDataView input)
+    {
+        var col = input.Schema.GetColumnOrNull(_options.InputColumnName);
+        if (col == null)
+            throw new ArgumentException(
+                $"Input schema does not contain column '{_options.InputColumnName}'.");
+
+        var model = new Model(_options.ModelPath);
+        var tokenizer = new Tokenizer(model);
+        return new OnnxTextGenerationTransformer(_mlContext, _options, model, tokenizer);
+    }
+
+    public SchemaShape GetOutputSchema(SchemaShape inputSchema)
+    {
+        var inputCol = inputSchema.FirstOrDefault(c => c.Name == _options.InputColumnName);
+        if (inputCol.Name == null)
+            throw new ArgumentException(
+                $"Input schema does not contain column '{_options.InputColumnName}'.");
+
+        var result = inputSchema.ToDictionary(x => x.Name);
+
+        var colCtor = typeof(SchemaShape.Column).GetConstructors(
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)[0];
+        var outputCol = (SchemaShape.Column)colCtor.Invoke([
+            _options.OutputColumnName,
+            SchemaShape.Column.VectorKind.Scalar,
+            (DataViewType)TextDataViewType.Instance,
+            false,
+            (SchemaShape?)null
+        ]);
+        result[_options.OutputColumnName] = outputCol;
+
+        return new SchemaShape(result.Values);
+    }
+}

--- a/src/MLNet.TextGeneration.OnnxGenAI/OnnxTextGenerationOptions.cs
+++ b/src/MLNet.TextGeneration.OnnxGenAI/OnnxTextGenerationOptions.cs
@@ -1,0 +1,34 @@
+namespace MLNet.TextGeneration.OnnxGenAI;
+
+/// <summary>
+/// Configuration for the ONNX Runtime GenAI text generation transform.
+/// </summary>
+public class OnnxTextGenerationOptions
+{
+    /// <summary>Path to the ONNX GenAI model directory.</summary>
+    public required string ModelPath { get; set; }
+
+    /// <summary>Name of the input text column. Default: "Text".</summary>
+    public string InputColumnName { get; set; } = "Text";
+
+    /// <summary>Name of the output generated text column. Default: "GeneratedText".</summary>
+    public string OutputColumnName { get; set; } = "GeneratedText";
+
+    /// <summary>Maximum generation length in tokens. Default: 512.</summary>
+    public int MaxLength { get; set; } = 512;
+
+    /// <summary>Sampling temperature. Default: 0.7.</summary>
+    public float Temperature { get; set; } = 0.7f;
+
+    /// <summary>Top-p (nucleus) sampling threshold. Default: 0.9.</summary>
+    public float TopP { get; set; } = 0.9f;
+
+    /// <summary>Optional system prompt prepended to each request.</summary>
+    public string? SystemPrompt { get; set; }
+
+    /// <summary>
+    /// Optional prompt template. Use {0} as placeholder for the user prompt.
+    /// If set, overrides SystemPrompt formatting.
+    /// </summary>
+    public string? PromptTemplate { get; set; }
+}

--- a/src/MLNet.TextGeneration.OnnxGenAI/OnnxTextGenerationTransformer.cs
+++ b/src/MLNet.TextGeneration.OnnxGenAI/OnnxTextGenerationTransformer.cs
@@ -1,0 +1,161 @@
+using System.Text;
+using Microsoft.ML;
+using Microsoft.ML.Data;
+using Microsoft.ML.OnnxRuntimeGenAI;
+
+namespace MLNet.TextGeneration.OnnxGenAI;
+
+/// <summary>
+/// ML.NET ITransformer that generates text using ONNX Runtime GenAI.
+/// Uses eager evaluation with autoregressive token generation.
+/// Owns the Model and Tokenizer lifecycle.
+/// </summary>
+public sealed class OnnxTextGenerationTransformer : ITransformer, IDisposable
+{
+    private readonly MLContext _mlContext;
+    private readonly OnnxTextGenerationOptions _options;
+    private readonly Model _model;
+    private readonly Tokenizer _tokenizer;
+
+    public bool IsRowToRowMapper => true;
+
+    internal OnnxTextGenerationTransformer(
+        MLContext mlContext,
+        OnnxTextGenerationOptions options,
+        Model model,
+        Tokenizer tokenizer)
+    {
+        _mlContext = mlContext;
+        _options = options;
+        _model = model;
+        _tokenizer = tokenizer;
+    }
+
+    public IDataView Transform(IDataView input)
+    {
+        var prompts = ReadTextColumn(input);
+        if (prompts.Count == 0)
+            return BuildOutputDataView(prompts, []);
+
+        var responses = new List<string>(prompts.Count);
+        foreach (var prompt in prompts)
+        {
+            var formatted = FormatPrompt(prompt);
+            responses.Add(RunGeneration(formatted));
+        }
+
+        return BuildOutputDataView(prompts, responses);
+    }
+
+    /// <summary>
+    /// Generates text responses for the given prompts directly, without ML.NET IDataView overhead.
+    /// </summary>
+    public string[] Generate(IReadOnlyList<string> prompts)
+    {
+        var results = new string[prompts.Count];
+        for (int i = 0; i < prompts.Count; i++)
+        {
+            var formatted = FormatPrompt(prompts[i]);
+            results[i] = RunGeneration(formatted);
+        }
+
+        return results;
+    }
+
+    public DataViewSchema GetOutputSchema(DataViewSchema inputSchema)
+    {
+        var builder = new DataViewSchema.Builder();
+        builder.AddColumns(inputSchema);
+        builder.AddColumn(_options.OutputColumnName, TextDataViewType.Instance);
+        return builder.ToSchema();
+    }
+
+    public IRowToRowMapper GetRowToRowMapper(DataViewSchema inputSchema)
+        => throw new NotSupportedException();
+
+    void ICanSaveModel.Save(ModelSaveContext ctx)
+        => throw new NotSupportedException(
+            "Cannot save an ONNX GenAI text generation transform. " +
+            "The model must be loaded from disk at runtime.");
+
+    public void Dispose()
+    {
+        _tokenizer.Dispose();
+        _model.Dispose();
+    }
+
+    private string FormatPrompt(string prompt)
+    {
+        if (!string.IsNullOrEmpty(_options.PromptTemplate))
+            return string.Format(_options.PromptTemplate, prompt);
+
+        if (!string.IsNullOrEmpty(_options.SystemPrompt))
+            return $"<|system|>\n{_options.SystemPrompt}<|end|>\n<|user|>\n{prompt}<|end|>\n<|assistant|>\n";
+
+        return prompt;
+    }
+
+    private string RunGeneration(string formattedPrompt)
+    {
+        var sequences = _tokenizer.Encode(formattedPrompt);
+
+        using var generatorParams = new GeneratorParams(_model);
+        generatorParams.SetSearchOption("max_length", _options.MaxLength);
+        generatorParams.SetSearchOption("temperature", _options.Temperature);
+        generatorParams.SetSearchOption("top_p", _options.TopP);
+
+        using var generator = new Generator(_model, generatorParams);
+        generator.AppendTokenSequences(sequences);
+        using var tokenizerStream = _tokenizer.CreateStream();
+
+        var result = new StringBuilder();
+        while (!generator.IsDone())
+        {
+            generator.GenerateNextToken();
+            var newToken = generator.GetSequence(0UL);
+            var tokenId = newToken[^1];
+            result.Append(tokenizerStream.Decode(tokenId));
+        }
+
+        return result.ToString();
+    }
+
+    private List<string> ReadTextColumn(IDataView dataView)
+    {
+        var texts = new List<string>();
+        var col = dataView.Schema[_options.InputColumnName];
+        using var cursor = dataView.GetRowCursor(new[] { col });
+        var getter = cursor.GetGetter<ReadOnlyMemory<char>>(col);
+
+        ReadOnlyMemory<char> value = default;
+        while (cursor.MoveNext())
+        {
+            getter(ref value);
+            texts.Add(value.ToString());
+        }
+
+        return texts;
+    }
+
+    private IDataView BuildOutputDataView(List<string> prompts, List<string> responses)
+    {
+        var rows = new List<TextGenerationRow>();
+
+        for (int i = 0; i < prompts.Count; i++)
+        {
+            rows.Add(new TextGenerationRow
+            {
+                Text = prompts[i],
+                GeneratedText = i < responses.Count ? responses[i] : ""
+            });
+        }
+
+        return _mlContext.Data.LoadFromEnumerable(rows);
+    }
+
+    private sealed class TextGenerationRow
+    {
+        public string Text { get; set; } = "";
+        public string GeneratedText { get; set; } = "";
+    }
+}

--- a/src/MLNet.TextInference.Onnx/ChatClientEstimator.cs
+++ b/src/MLNet.TextInference.Onnx/ChatClientEstimator.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.AI;
+using Microsoft.ML;
+using Microsoft.ML.Data;
+
+namespace MLNet.TextInference.Onnx;
+
+/// <summary>
+/// Configuration for the provider-agnostic text generation transform.
+/// </summary>
+public class TextGenerationOptions
+{
+    /// <summary>Name of the input text column. Default: "Text".</summary>
+    public string InputColumnName { get; set; } = "Text";
+
+    /// <summary>Name of the output generated text column. Default: "GeneratedText".</summary>
+    public string OutputColumnName { get; set; } = "GeneratedText";
+
+    /// <summary>Optional system prompt prepended to each request.</summary>
+    public string? SystemPrompt { get; set; }
+
+    /// <summary>Maximum number of tokens to generate.</summary>
+    public int? MaxOutputTokens { get; set; }
+
+    /// <summary>Sampling temperature.</summary>
+    public float? Temperature { get; set; }
+
+    /// <summary>Top-p (nucleus) sampling threshold.</summary>
+    public float? TopP { get; set; }
+}
+
+/// <summary>
+/// ML.NET IEstimator that wraps any IChatClient to produce text generation within a pipeline.
+/// Provider-agnostic — works with ONNX Runtime GenAI, OpenAI, Azure OpenAI, Ollama, or any MEAI implementation.
+/// </summary>
+public sealed class ChatClientEstimator : IEstimator<ChatClientTransformer>
+{
+    private readonly MLContext _mlContext;
+    private readonly IChatClient _chatClient;
+    private readonly TextGenerationOptions _options;
+
+    public ChatClientEstimator(
+        MLContext mlContext,
+        IChatClient chatClient,
+        TextGenerationOptions? options = null)
+    {
+        _mlContext = mlContext ?? throw new ArgumentNullException(nameof(mlContext));
+        _chatClient = chatClient ?? throw new ArgumentNullException(nameof(chatClient));
+        _options = options ?? new TextGenerationOptions();
+    }
+
+    public ChatClientTransformer Fit(IDataView input)
+    {
+        var col = input.Schema.GetColumnOrNull(_options.InputColumnName);
+        if (col == null)
+            throw new ArgumentException(
+                $"Input schema does not contain column '{_options.InputColumnName}'.");
+
+        return new ChatClientTransformer(_mlContext, _chatClient, _options);
+    }
+
+    public SchemaShape GetOutputSchema(SchemaShape inputSchema)
+    {
+        var inputCol = inputSchema.FirstOrDefault(c => c.Name == _options.InputColumnName);
+        if (inputCol.Name == null)
+            throw new ArgumentException(
+                $"Input schema does not contain column '{_options.InputColumnName}'.");
+
+        var result = inputSchema.ToDictionary(x => x.Name);
+
+        var colCtor = typeof(SchemaShape.Column).GetConstructors(
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)[0];
+        var outputCol = (SchemaShape.Column)colCtor.Invoke([
+            _options.OutputColumnName,
+            SchemaShape.Column.VectorKind.Scalar,
+            (DataViewType)TextDataViewType.Instance,
+            false,
+            (SchemaShape?)null
+        ]);
+        result[_options.OutputColumnName] = outputCol;
+
+        return new SchemaShape(result.Values);
+    }
+}

--- a/src/MLNet.TextInference.Onnx/ChatClientTransformer.cs
+++ b/src/MLNet.TextInference.Onnx/ChatClientTransformer.cs
@@ -1,0 +1,142 @@
+using Microsoft.Extensions.AI;
+using Microsoft.ML;
+using Microsoft.ML.Data;
+
+namespace MLNet.TextInference.Onnx;
+
+/// <summary>
+/// ML.NET ITransformer that generates text using any IChatClient.
+/// Uses eager evaluation — each prompt is sent individually to the chat client.
+/// </summary>
+public sealed class ChatClientTransformer : ITransformer
+{
+    private readonly MLContext _mlContext;
+    private readonly IChatClient _chatClient;
+    private readonly TextGenerationOptions _options;
+
+    public bool IsRowToRowMapper => true;
+
+    internal IChatClient ChatClient => _chatClient;
+
+    internal ChatClientTransformer(
+        MLContext mlContext,
+        IChatClient chatClient,
+        TextGenerationOptions options)
+    {
+        _mlContext = mlContext;
+        _chatClient = chatClient;
+        _options = options;
+    }
+
+    public IDataView Transform(IDataView input)
+    {
+        var prompts = ReadTextColumn(input);
+        if (prompts.Count == 0)
+            return BuildOutputDataView(prompts, []);
+
+        var responses = new List<string>(prompts.Count);
+        foreach (var prompt in prompts)
+        {
+            var messages = new List<ChatMessage>();
+            if (!string.IsNullOrEmpty(_options.SystemPrompt))
+                messages.Add(new ChatMessage(ChatRole.System, _options.SystemPrompt));
+            messages.Add(new ChatMessage(ChatRole.User, prompt));
+
+            var chatOptions = new ChatOptions();
+            if (_options.MaxOutputTokens.HasValue)
+                chatOptions.MaxOutputTokens = _options.MaxOutputTokens.Value;
+            if (_options.Temperature.HasValue)
+                chatOptions.Temperature = _options.Temperature.Value;
+            if (_options.TopP.HasValue)
+                chatOptions.TopP = _options.TopP.Value;
+
+            var response = _chatClient.GetResponseAsync(messages, chatOptions).GetAwaiter().GetResult();
+            responses.Add(response.Text ?? "");
+        }
+
+        return BuildOutputDataView(prompts, responses);
+    }
+
+    /// <summary>
+    /// Generates text responses for the given prompts directly, without ML.NET IDataView overhead.
+    /// </summary>
+    public string[] Generate(IReadOnlyList<string> prompts)
+    {
+        var results = new string[prompts.Count];
+        for (int i = 0; i < prompts.Count; i++)
+        {
+            var messages = new List<ChatMessage>();
+            if (!string.IsNullOrEmpty(_options.SystemPrompt))
+                messages.Add(new ChatMessage(ChatRole.System, _options.SystemPrompt));
+            messages.Add(new ChatMessage(ChatRole.User, prompts[i]));
+
+            var chatOptions = new ChatOptions();
+            if (_options.MaxOutputTokens.HasValue)
+                chatOptions.MaxOutputTokens = _options.MaxOutputTokens.Value;
+            if (_options.Temperature.HasValue)
+                chatOptions.Temperature = _options.Temperature.Value;
+            if (_options.TopP.HasValue)
+                chatOptions.TopP = _options.TopP.Value;
+
+            var response = _chatClient.GetResponseAsync(messages, chatOptions).GetAwaiter().GetResult();
+            results[i] = response.Text ?? "";
+        }
+
+        return results;
+    }
+
+    public DataViewSchema GetOutputSchema(DataViewSchema inputSchema)
+    {
+        var builder = new DataViewSchema.Builder();
+        builder.AddColumns(inputSchema);
+        builder.AddColumn(_options.OutputColumnName, TextDataViewType.Instance);
+        return builder.ToSchema();
+    }
+
+    public IRowToRowMapper GetRowToRowMapper(DataViewSchema inputSchema)
+        => throw new NotSupportedException();
+
+    void ICanSaveModel.Save(ModelSaveContext ctx)
+        => throw new NotSupportedException(
+            "Cannot save a provider-agnostic text generation transform. " +
+            "The IChatClient instance cannot be serialized.");
+
+    private List<string> ReadTextColumn(IDataView dataView)
+    {
+        var texts = new List<string>();
+        var col = dataView.Schema[_options.InputColumnName];
+        using var cursor = dataView.GetRowCursor(new[] { col });
+        var getter = cursor.GetGetter<ReadOnlyMemory<char>>(col);
+
+        ReadOnlyMemory<char> value = default;
+        while (cursor.MoveNext())
+        {
+            getter(ref value);
+            texts.Add(value.ToString());
+        }
+
+        return texts;
+    }
+
+    private IDataView BuildOutputDataView(List<string> prompts, List<string> responses)
+    {
+        var rows = new List<TextGenerationRow>();
+
+        for (int i = 0; i < prompts.Count; i++)
+        {
+            rows.Add(new TextGenerationRow
+            {
+                Text = prompts[i],
+                GeneratedText = i < responses.Count ? responses[i] : ""
+            });
+        }
+
+        return _mlContext.Data.LoadFromEnumerable(rows);
+    }
+
+    private sealed class TextGenerationRow
+    {
+        public string Text { get; set; } = "";
+        public string GeneratedText { get; set; } = "";
+    }
+}

--- a/src/MLNet.TextInference.Onnx/MLContextExtensions.cs
+++ b/src/MLNet.TextInference.Onnx/MLContextExtensions.cs
@@ -79,6 +79,17 @@ public static class MLContextExtensions
         return new OnnxTextClassificationEstimator(catalog.GetMLContext(), options);
     }
 
+    /// <summary>
+    /// Creates a provider-agnostic text generation transform that wraps any IChatClient.
+    /// </summary>
+    public static ChatClientEstimator TextGeneration(
+        this TransformsCatalog catalog,
+        IChatClient chatClient,
+        TextGenerationOptions? options = null)
+    {
+        return new ChatClientEstimator(catalog.GetMLContext(), chatClient, options);
+    }
+
     // Gets the real MLContext from TransformsCatalog via reflection so that
     // context-level settings (e.g. GpuDeviceId) are preserved.
     private static MLContext GetMLContext(this TransformsCatalog catalog)


### PR DESCRIPTION
Add text generation support via two components:

**Phase 1: ChatClientTransformer** (provider-agnostic, in existing project)
- `TextGenerationOptions` config class
- `ChatClientEstimator : IEstimator<ChatClientTransformer>`
- `ChatClientTransformer : ITransformer` with eager Transform() and direct Generate() face
- Extension method: `mlContext.Transforms.TextGeneration(chatClient)`

**Phase 2: OnnxTextGenerationTransformer** (new project)
- New `MLNet.TextGeneration.OnnxGenAI` project with ORT GenAI dependency
- `OnnxTextGenerationEstimator/Transformer` with autoregressive generation loop
- Extension method: `mlContext.Transforms.OnnxTextGeneration(options)`

**Samples**: TextGenerationMeai, TextGenerationLocal

Depends on #10 (rename/restructure).
Closes #8