### PR TITLE
Add tokenizer.json (HuggingFace fast tokenizer) support

### DIFF
--- a/src/MLNet.TextInference.Onnx/TextTokenizerEstimator.cs
+++ b/src/MLNet.TextInference.Onnx/TextTokenizerEstimator.cs
@@ -318,12 +318,14 @@ public sealed class TextTokenizerEstimator : IEstimator<TextTokenizerTransformer
             throw new InvalidOperationException(
                 $"tokenizer.json at '{path}' has no 'model.type' property.");
 
-        var modelType = typeElement.GetString();
+        var modelType = typeElement.GetString()
+            ?? throw new InvalidOperationException(
+                $"tokenizer.json at '{path}' has null 'model.type' property.");
 
         return modelType switch
         {
             "BPE" => LoadBpeFromTokenizerJson(model, path),
-            "WordPiece" => LoadWordPieceFromTokenizerJson(model, path),
+            "WordPiece" => LoadWordPieceFromTokenizerJson(model, root, path),
             "Unigram" => throw new NotSupportedException(
                 $"Unigram tokenizer.json is not directly supported. " +
                 $"Point TokenizerPath at the directory containing the .model file instead, " +
@@ -351,7 +353,12 @@ public sealed class TextTokenizerEstimator : IEstimator<TextTokenizerTransformer
         {
             var sb = new StringBuilder();
             foreach (var merge in mergesElement.EnumerateArray())
-                sb.AppendLine(merge.GetString());
+            {
+                var mergeString = merge.GetString()
+                    ?? throw new InvalidOperationException(
+                        $"BPE model in '{path}' has a null entry in 'merges', which is not allowed.");
+                sb.AppendLine(mergeString);
+            }
             mergesStream = new MemoryStream(Encoding.UTF8.GetBytes(sb.ToString()));
         }
 
@@ -365,11 +372,21 @@ public sealed class TextTokenizerEstimator : IEstimator<TextTokenizerTransformer
         }
     }
 
-    private static Tokenizer LoadWordPieceFromTokenizerJson(JsonElement model, string path)
+    private static Tokenizer LoadWordPieceFromTokenizerJson(JsonElement model, JsonElement root, string path)
     {
         if (!model.TryGetProperty("vocab", out var vocabElement))
             throw new InvalidOperationException(
                 $"WordPiece model in '{path}' has no 'vocab' property.");
+
+        // Check normalizer for lowercase setting (e.g. bert-base-uncased)
+        var lowerCase = false;
+        if (root.TryGetProperty("normalizer", out var normalizer)
+            && normalizer.ValueKind == JsonValueKind.Object
+            && normalizer.TryGetProperty("lowercase", out var lc)
+            && lc.ValueKind == JsonValueKind.True)
+        {
+            lowerCase = true;
+        }
 
         // model.vocab is {"token": id, ...} — sort by ID and write as vocab.txt format (one token per line)
         var vocabPairs = new SortedDictionary<int, string>();
@@ -381,7 +398,7 @@ public sealed class TextTokenizerEstimator : IEstimator<TextTokenizerTransformer
             sb.AppendLine(kvp.Value);
 
         using var vocabStream = new MemoryStream(Encoding.UTF8.GetBytes(sb.ToString()));
-        return BertTokenizer.Create(vocabStream);
+        return BertTokenizer.Create(vocabStream, new BertOptions { LowerCaseBeforeTokenization = lowerCase });
     }
 
     private static Tokenizer LoadFromVocabFile(string path)


### PR DESCRIPTION
## Summary

Adds support for loading tokenizers from HuggingFace's `tokenizer.json` fast tokenizer format  the single-file format that contains the complete tokenizer pipeline (vocab, merges, normalizer, pre/post-processing) present on virtually every model on the Hub.

Closes #21
Related: #18

## Changes

### `LoadTokenizer()` (line ~175)
- Added `tokenizer.json` as a recognized file name (between `tokenizer_config.json` and vocab file fallback)

### `LoadFromDirectory()` (line ~204)
- Added `tokenizer.json` as **last-resort fallback**  only used when no `tokenizer_config.json`, `vocab.txt`, or `.model` files exist in the directory. This preserves all existing behavior.

### New methods

| Method | Purpose |
|--------|---------|
| `LoadFromHuggingFaceTokenizerJson()` | Parses JSON, reads `model.type`, dispatches to BPE/WordPiece. Throws `NotSupportedException` for Unigram with guidance. |
| `LoadBpeFromTokenizerJson()` | Extracts `model.vocab` (JSON dict, same format as vocab.json) + `model.merges` (JSON array), creates in-memory streams, calls `BpeTokenizer.Create()` |
| `LoadWordPieceFromTokenizerJson()` | Extracts `model.vocab`, sorts by ID, writes vocab.txt format, calls `BertTokenizer.Create()` |

### Doc comments & error messages
- Updated `TokenizerPath` XML doc to list `tokenizer.json` as a supported format
- Updated `LoadTokenizer()` XML doc
- Updated `LoadFromDirectory()` error message to include `tokenizer.json`

## Design decisions

1. **Unigram  throw, don't attempt**: There's no way to construct a `LlamaTokenizer` from JSON vocab+scores (it requires protobuf `.model`). Unigram models always ship `.model` files alongside `tokenizer.json`, so users should point at the directory instead.

2. **Last-resort in directory mode**: `tokenizer.json` is checked only after all other known files. This ensures zero behavioral change for existing users.

3. **No new dependencies**: Uses only `System.Text.Json` (already imported) and `Microsoft.ML.Tokenizers` (already a dependency).

## Testing suggestions

| # | Scenario | Model to test with |
|---|----------|-------------------|
| 1 | BPE tokenizer.json (direct file) | [SamLowe/roberta-base-go_emotions](https://huggingface.co/SamLowe/roberta-base-go_emotions/resolve/main/tokenizer.json) |
| 2 | WordPiece tokenizer.json (direct file) | [bert-base-uncased](https://huggingface.co/google-bert/bert-base-uncased/resolve/main/tokenizer.json) |
| 3 | Directory with only tokenizer.json | Any BPE model |
| 4 | Backward compat (dir with vocab.txt + tokenizer.json) | Any BERT model  should use vocab.txt |
| 5 | Unigram rejection | [DeBERTa](https://huggingface.co/MoritzLaurer/DeBERTa-v3-base-mnli-fever-anli/resolve/main/tokenizer.json)  throws NotSupportedException |
| 6 | Malformed tokenizer.json | Missing `model` property  throws InvalidOperationException |