### PR TITLE
Update docs for tokenizer.json support and new tokenizer classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This project implements custom transforms using direct `IEstimator<T>` / `ITrans
 - **Text-pair tokenization** — cross-encoder reranking uses `[CLS] A [SEP] B [SEP]` with token type IDs for query-document pairs
 - **Token offset tracking** — NER tokenization preserves character offsets via `EncodeToTokens()` for mapping entities back to source text
 - **Multi-output ONNX scoring** — QA models produce separate start/end logit tensors via `AdditionalOutputTensorNames`
-- **Smart tokenizer resolution** — point to a directory; auto-detects from `tokenizer_config.json` or known vocab files (BPE, SentencePiece, WordPiece)
+- **Smart tokenizer resolution** — point to a directory; auto-detects from `tokenizer_config.json`, known vocab files (BPE, SentencePiece, WordPiece), or HuggingFace `tokenizer.json` (fast tokenizer)
 - **ONNX auto-discovery** — automatically detects input/output tensor names, shapes, and dimensions from model metadata
 - **Self-contained save/load** — serializes to a portable `.mlnet` zip file containing the ONNX model, tokenizer, and config
 - **SIMD-accelerated post-processing** — pooling and normalization use `TensorPrimitives` for hardware-vectorized math

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -233,11 +233,12 @@ The all-MiniLM-L6-v2 model (and most BERT-derived sentence-transformers) uses **
 
 Rather than requiring users to know which tokenizer type their model uses, `LoadTokenizer()` uses a **smart resolution** strategy via a single `TokenizerPath` property:
 
-1. **Directory with `tokenizer_config.json`** → reads the HuggingFace config's `tokenizer_class` field (e.g., `"BertTokenizer"`, `"XLMRobertaTokenizer"`, `"GPT2Tokenizer"`), maps it to the appropriate `Microsoft.ML.Tokenizers` class, and loads sibling vocab files. Also applies config options like `do_lower_case`.
-2. **Directory without config** → scans for known files (`vocab.txt` → BERT, `tokenizer.model` → SentencePiece).
+1. **Directory with `tokenizer_config.json`** → reads the HuggingFace config's `tokenizer_class` field (e.g., `"BertTokenizer"`, `"XLMRobertaTokenizer"`, `"DebertaV2Tokenizer"`, `"GPT2Tokenizer"`), maps it to the appropriate `Microsoft.ML.Tokenizers` class, and loads sibling vocab files. Also applies config options like `do_lower_case`.
+2. **Directory without config** → scans for known files (`vocab.txt` → BERT, `tokenizer.model`/`sentencepiece.bpe.model`/`spm.model` → SentencePiece, `tokenizer.json` → BPE/WordPiece fast tokenizer as last resort).
 3. **`tokenizer_config.json` file** → same as (1), uses the file's parent directory for sibling resolution.
-4. **Direct vocab file** → infers type from extension (`.txt` → BERT, `.model` → SentencePiece).
-5. **Pre-constructed `Tokenizer` instance** → the `Tokenizer` property on `TextTokenizerOptions` bypasses all resolution. Use this for exotic formats or shared tokenizer instances.
+4. **`tokenizer.json` file** → HuggingFace fast tokenizer format. Parses the `model.type` field and extracts vocab/merges from JSON to construct `BpeTokenizer` (for BPE models) or `BertTokenizer` (for WordPiece models). Also reads the `normalizer.lowercase` setting for uncased models. Throws `NotSupportedException` for Unigram models (use the `.model` protobuf file instead).
+5. **Direct vocab file** → infers type from extension (`.txt` → BERT, `.model` → SentencePiece).
+6. **Pre-constructed `Tokenizer` instance** → the `Tokenizer` property on `TextTokenizerOptions` bypasses all resolution. Use this for exotic formats or shared tokenizer instances.
 
 This design mirrors HuggingFace's `AutoTokenizer.from_pretrained(path)` pattern — one input, smart resolution — while keeping the API surface minimal (two properties: `Tokenizer` and `TokenizerPath`).
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -177,12 +177,21 @@ private static float[] WeightedMeanPool(
 | Source | Tokenizer | Vocab Files |
 |--------|-----------|-------------|
 | `tokenizer_class: "BertTokenizer"` | `BertTokenizer` | `vocab.txt` |
-| `tokenizer_class: "XLMRobertaTokenizer"` | `LlamaTokenizer` | `sentencepiece.bpe.model`, `tokenizer.model` |
-| `tokenizer_class: "LlamaTokenizer"` | `LlamaTokenizer` | `tokenizer.model` |
+| `tokenizer_class: "DistilBertTokenizer"` | `BertTokenizer` | `vocab.txt` |
+| `tokenizer_class: "DebertaV2Tokenizer"` | `LlamaTokenizer` | `sentencepiece.bpe.model`, `tokenizer.model`, `spm.model` |
+| `tokenizer_class: "DebertaTokenizer"` | `LlamaTokenizer` | `sentencepiece.bpe.model`, `tokenizer.model`, `spm.model` |
+| `tokenizer_class: "XLMRobertaTokenizer"` | `LlamaTokenizer` | `sentencepiece.bpe.model`, `tokenizer.model`, `spm.model` |
+| `tokenizer_class: "LlamaTokenizer"` | `LlamaTokenizer` | `sentencepiece.bpe.model`, `tokenizer.model`, `spm.model` |
+| `tokenizer_class: "CamembertTokenizer"` | `LlamaTokenizer` | `sentencepiece.bpe.model`, `tokenizer.model`, `spm.model` |
+| `tokenizer_class: "T5Tokenizer"` | `LlamaTokenizer` | `sentencepiece.bpe.model`, `tokenizer.model`, `spm.model` |
+| `tokenizer_class: "AlbertTokenizer"` | `LlamaTokenizer` | `sentencepiece.bpe.model`, `tokenizer.model`, `spm.model` |
 | `tokenizer_class: "GPT2Tokenizer"` | `BpeTokenizer` | `vocab.json` + `merges.txt` |
 | `tokenizer_class: "RobertaTokenizer"` | `BpeTokenizer` | `vocab.json` + `merges.txt` |
+| Direct `tokenizer.json` file (BPE) | `BpeTokenizer` | Extracts `model.vocab` + `model.merges` from JSON |
+| Direct `tokenizer.json` file (WordPiece) | `BertTokenizer` | Extracts `model.vocab` from JSON; reads `normalizer.lowercase` |
 | Direct `.txt` file | `BertTokenizer` | (the file itself) |
 | Direct `.model` file | `LlamaTokenizer` | (the file itself) |
+| Directory fallback: `tokenizer.json` | `BpeTokenizer` or `BertTokenizer` | Last resort when no other tokenizer files found |
 
 ### Adding a new tokenizer type
 
@@ -216,6 +225,14 @@ When `TokenizerPath` points to a directory or `tokenizer_config.json`, the loade
 2. Dispatches to the appropriate factory method
 3. Applies config properties (e.g., `do_lower_case` → `BertOptions.LowerCaseBeforeTokenization`)
 4. Finds sibling vocab files in the same directory
+
+When `TokenizerPath` points to a `tokenizer.json` file (HuggingFace fast tokenizer):
+1. Parses the JSON and reads `model.type` (`"BPE"`, `"WordPiece"`, or `"Unigram"`)
+2. For **BPE**: extracts `model.vocab` (JSON dict, same format as `vocab.json`) and `model.merges` (JSON array), creates in-memory streams, and calls `BpeTokenizer.Create()`
+3. For **WordPiece**: extracts `model.vocab`, sorts by ID, writes as `vocab.txt` format, reads `normalizer.lowercase` for uncased models, and calls `BertTokenizer.Create()` with appropriate `BertOptions`
+4. For **Unigram**: throws `NotSupportedException` — Unigram models always ship a `.model` protobuf file alongside `tokenizer.json`, so users should point at the directory instead
+
+When a directory contains no `tokenizer_config.json` or known vocab files, `tokenizer.json` is checked as a **last-resort fallback**.
 
 This mirrors HuggingFace's `AutoTokenizer.from_pretrained()` pattern.
 

--- a/docs/modular-pipeline-changes.md
+++ b/docs/modular-pipeline-changes.md
@@ -215,7 +215,7 @@ var estimator = mlContext.Transforms.TextEmbedding(anyGenerator);
 **Decision:** `TokenizerPath` now accepts a **directory** (not just a file). When given a directory, the tokenizer estimator:
 1. Looks for `tokenizer_config.json` and reads `tokenizer_class` to determine the type
 2. Dispatches to the appropriate tokenizer: `BpeTokenizer`, `LlamaTokenizer` (SentencePiece), or `BertTokenizer` (WordPiece)
-3. Falls back to heuristic detection based on known file patterns (`vocab.txt` → WordPiece, `tokenizer.json` → BPE, `tokenizer.model` → SentencePiece)
+3. Falls back to heuristic detection based on known file patterns (`vocab.txt` → WordPiece, `tokenizer.model`/`sentencepiece.bpe.model`/`spm.model` → SentencePiece, `tokenizer.json` → BPE or WordPiece as last resort)
 
 **Rationale:** HuggingFace models use different tokenizer types. Requiring the user to know which tokenizer file to point to and what type it is creates unnecessary friction. With directory-based resolution, you just point to the model directory and the library figures it out.
 


### PR DESCRIPTION
## Summary

Updates documentation across 4 files to reflect the tokenizer loading changes from PR #19 and PR #22.

### What changed in the code (already merged)

- **PR #19**: Added `DebertaV2Tokenizer`, `DebertaTokenizer` to `LoadFromConfig()` switch; added `spm.model` to SentencePiece candidates
- **PR #22**: Added `tokenizer.json` (HuggingFace fast tokenizer) support  BPE and WordPiece model types, with `normalizer.lowercase` for uncased models

### Doc updates

| File | Change |
|------|--------|
| **README.md** | Feature bullet now mentions `tokenizer.json` |
| **docs/design-decisions.md** | Resolution steps updated: added `tokenizer.json` as step 4, mentioned `DebertaV2Tokenizer` and `spm.model` |
| **docs/extending.md** | Tokenizer format table expanded from 7  16 entries (all supported `tokenizer_class` values + `tokenizer.json` + `spm.model`). Resolution flow section now documents the full `tokenizer.json` parsing pipeline (BPE/WordPiece/Unigram rejection). |
| **docs/modular-pipeline-changes.md** | Fixed directory fallback description: `tokenizer.json` supports both BPE and WordPiece (not just BPE) |

No code changes  documentation only.