### PR TITLE
Fix DiscoverModelMetadata throw on QA models with dynamic output dims

### DIFF
--- a/src/MLNet.TextInference.Onnx/OnnxTextModelScorerEstimator.cs
+++ b/src/MLNet.TextInference.Onnx/OnnxTextModelScorerEstimator.cs
@@ -186,6 +186,8 @@ public sealed class OnnxTextModelScorerEstimator : IEstimator<OnnxTextModelScore
             var dims = outputMeta[outputName].Dimensions;
             hasPooledOutput = !dims.Contains(-1) && dims.Length == 2;
             hiddenDim = (int)dims.Last();
+            if (hiddenDim <= 0)
+                hiddenDim = _options.MaxTokenLength;
             outputRank = dims.Length;
         }
         else if (_options.PreferredOutputNames != null)
@@ -197,6 +199,8 @@ public sealed class OnnxTextModelScorerEstimator : IEstimator<OnnxTextModelScore
                 var dims = outputMeta[preferred].Dimensions;
                 hasPooledOutput = !dims.Contains(-1) && dims.Length == 2;
                 hiddenDim = (int)dims.Last();
+                if (hiddenDim <= 0)
+                    hiddenDim = _options.MaxTokenLength;
                 outputRank = dims.Length;
             }
             else
@@ -205,6 +209,8 @@ public sealed class OnnxTextModelScorerEstimator : IEstimator<OnnxTextModelScore
                 var dims = outputMeta[outputName].Dimensions;
                 hasPooledOutput = !dims.Contains(-1) && dims.Length == 2;
                 hiddenDim = (int)dims.Last();
+                if (hiddenDim <= 0)
+                    hiddenDim = _options.MaxTokenLength;
                 outputRank = dims.Length;
             }
         }
@@ -216,6 +222,8 @@ public sealed class OnnxTextModelScorerEstimator : IEstimator<OnnxTextModelScore
                 outputName = pooledName;
                 hasPooledOutput = true;
                 hiddenDim = (int)outputMeta[pooledName].Dimensions.Last();
+                if (hiddenDim <= 0)
+                    hiddenDim = _options.MaxTokenLength;
                 outputRank = 2;
             }
             else
@@ -225,6 +233,8 @@ public sealed class OnnxTextModelScorerEstimator : IEstimator<OnnxTextModelScore
                     outputMeta.Keys.First());
                 hasPooledOutput = false;
                 hiddenDim = (int)outputMeta[outputName].Dimensions.Last();
+                if (hiddenDim <= 0)
+                    hiddenDim = _options.MaxTokenLength;
                 outputRank = 3;
             }
         }


### PR DESCRIPTION
## Summary

Fixes `DiscoverModelMetadata()` throwing `InvalidOperationException("Could not determine hidden dimension from ONNX output 'start_logits'")` when used with QA models whose output tensors have all-dynamic dimensions.

Fixes #25

## Root Cause

QA models (e.g. `minilm-uncased-squad2`) output `start_logits` and `end_logits` with shape `[batch_size, sequence_length]` where **both** dimensions are dynamic (`[-1, -1]`). The `hiddenDim = (int)dims.Last()` extraction yields `-1`, which triggers the guard clause.

The adjacent code for `AdditionalOutputTensorNames` already handled this correctly by falling back to `MaxTokenLength` when the last dimension is dynamic.

## Fix

Apply the same `MaxTokenLength` fallback after every `hiddenDim = (int)dims.Last()` assignment  all 5 branches in `DiscoverModelMetadata()`:

1. `OutputTensorName` explicit branch
2. `PreferredOutputNames` branch (preferred found)
3. `PreferredOutputNames` branch (preferred not found, fallback)
4. Auto-discovery pooled branch (`sentence_embedding` / `pooler_output`)
5. Auto-discovery unpooled branch (`last_hidden_state` / `output`)

The existing guard clause (`hiddenDim <= 0  throw`) is kept as a safety net for the edge case where `MaxTokenLength` is also `<= 0`.

## Impact

- **QA models**: No longer throws. `hiddenDim` resolves to `MaxTokenLength` (128 by default).
- **Embedding models**: Hidden dim is static (e.g., 384). Fallback never triggers. No behavior change.
- **Classification/NER/Reranking models**: 3D output tensors with static last dim. Fallback never triggers. No behavior change.

## Changes

`src/MLNet.TextInference.Onnx/OnnxTextModelScorerEstimator.cs`  10 lines added (2 per branch  5 branches)