### PR TITLE
Fix BPE text-pair tokenization and first context word drop

### DIFF
--- a/src/MLNet.TextInference.Onnx/TextTokenizerEstimator.cs
+++ b/src/MLNet.TextInference.Onnx/TextTokenizerEstimator.cs
@@ -79,6 +79,12 @@ public class TextTokenizerOptions
 
     /// <summary>Name of the output column for token end character offsets. Default: "TokenEndOffsets".</summary>
     public string TokenEndOffsetsColumnName { get; set; } = "TokenEndOffsets";
+
+    // Special token IDs populated during tokenizer loading from tokenizer_config.json.
+    // Used by text-pair tokenization to manually inject [CLS]/[SEP] tokens.
+    internal int? BosTokenId { get; set; }
+    internal int? SepTokenId { get; set; }
+    internal bool DoubleSeparator { get; set; }
 }
 
 /// <summary>
@@ -125,6 +131,10 @@ public sealed class TextTokenizerEstimator : IEstimator<TextTokenizerTransformer
         }
 
         var tokenizer = _options.Tokenizer ?? LoadTokenizer(_options.TokenizerPath!);
+
+        if (_options.BosTokenId == null && _options.TokenizerPath != null)
+            PopulateSpecialTokens(_options.TokenizerPath, _options);
+
         return new TextTokenizerTransformer(_mlContext, _options, tokenizer);
     }
 
@@ -432,5 +442,70 @@ public sealed class TextTokenizerEstimator : IEstimator<TextTokenizerTransformer
             (SchemaShape?)null
         ]);
         schema[name] = col;
+    }
+
+    /// <summary>
+    /// Extracts special token IDs (BOS/CLS and SEP) from tokenizer_config.json.
+    /// These are needed for manual special token injection in text-pair tokenization.
+    /// </summary>
+    private static void PopulateSpecialTokens(string tokenizerPath, TextTokenizerOptions options)
+    {
+        string? configPath = null;
+        if (Directory.Exists(tokenizerPath))
+            configPath = Path.Combine(tokenizerPath, "tokenizer_config.json");
+        else if (Path.GetFileName(tokenizerPath).Equals("tokenizer_config.json", StringComparison.OrdinalIgnoreCase))
+            configPath = tokenizerPath;
+
+        if (configPath == null || !File.Exists(configPath))
+            return;
+
+        var json = File.ReadAllText(configPath);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        var clsTokenStr = root.TryGetProperty("cls_token", out var cls) ? cls.GetString() : null;
+        var sepTokenStr = root.TryGetProperty("sep_token", out var sep) ? sep.GetString() : null;
+
+        // Resolve token string → ID via added_tokens_decoder
+        if (clsTokenStr != null && sepTokenStr != null
+            && root.TryGetProperty("added_tokens_decoder", out var decoder))
+        {
+            foreach (var entry in decoder.EnumerateObject())
+            {
+                if (!int.TryParse(entry.Name, out int tokenId)) continue;
+                var content = entry.Value.TryGetProperty("content", out var c) ? c.GetString() : null;
+                if (content == null) continue;
+
+                if (content == clsTokenStr && options.BosTokenId == null)
+                    options.BosTokenId = tokenId;
+                if (content == sepTokenStr && options.SepTokenId == null)
+                    options.SepTokenId = tokenId;
+            }
+        }
+
+        // Fallback: well-known defaults by tokenizer class
+        if (options.BosTokenId == null || options.SepTokenId == null)
+        {
+            var tokenizerClass = root.TryGetProperty("tokenizer_class", out var tc) ? tc.GetString() ?? "" : "";
+            if (tokenizerClass.EndsWith("Fast", StringComparison.Ordinal))
+                tokenizerClass = tokenizerClass[..^4];
+
+            (int? defaultBos, int? defaultSep) = tokenizerClass switch
+            {
+                "BertTokenizer" or "DistilBertTokenizer" => ((int?)101, (int?)102),
+                "RobertaTokenizer" or "GPT2Tokenizer" => ((int?)0, (int?)2),
+                "DebertaTokenizer" or "DebertaV2Tokenizer" => ((int?)1, (int?)2),
+                "XLMRobertaTokenizer" => ((int?)0, (int?)2),
+                _ => ((int?)null, (int?)null)
+            };
+            options.BosTokenId ??= defaultBos;
+            options.SepTokenId ??= defaultSep;
+        }
+
+        // RoBERTa-family uses double separator between segments: <s> A </s></s> B </s>
+        var tokClass = root.TryGetProperty("tokenizer_class", out var t) ? t.GetString() ?? "" : "";
+        if (tokClass.EndsWith("Fast", StringComparison.Ordinal))
+            tokClass = tokClass[..^4];
+        options.DoubleSeparator = tokClass is "RobertaTokenizer" or "GPT2Tokenizer" or "XLMRobertaTokenizer";
     }
 }

--- a/src/MLNet.TextInference.Onnx/TextTokenizerEstimator.cs
+++ b/src/MLNet.TextInference.Onnx/TextTokenizerEstimator.cs
@@ -132,8 +132,17 @@ public sealed class TextTokenizerEstimator : IEstimator<TextTokenizerTransformer
 
         var tokenizer = _options.Tokenizer ?? LoadTokenizer(_options.TokenizerPath!);
 
-        if (_options.BosTokenId == null && _options.TokenizerPath != null)
+        if ((_options.BosTokenId == null || _options.SepTokenId == null) && _options.TokenizerPath != null)
             PopulateSpecialTokens(_options.TokenizerPath, _options);
+
+        if (_options.SecondInputColumnName != null
+            && (_options.BosTokenId == null || _options.SepTokenId == null))
+        {
+            throw new InvalidOperationException(
+                "Text-pair tokenization requires special token IDs (BOS/CLS and SEP) but they could not be resolved. " +
+                "Ensure TokenizerPath points to a directory containing tokenizer_config.json with " +
+                "cls_token/sep_token definitions or added_tokens_decoder.");
+        }
 
         return new TextTokenizerTransformer(_mlContext, _options, tokenizer);
     }

--- a/src/MLNet.TextInference.Onnx/TextTokenizerTransformer.cs
+++ b/src/MLNet.TextInference.Onnx/TextTokenizerTransformer.cs
@@ -126,7 +126,7 @@ public sealed class TextTokenizerTransformer : ITransformer
 
     /// <summary>
     /// Direct face: tokenize text pairs for cross-encoder models.
-    /// Produces [CLS] A [SEP] B [SEP] with proper token_type_ids.
+    /// Produces [BOS] A [SEP] B [SEP] with proper token_type_ids.
     /// When OutputOffsets is true, records character offsets for B segment tokens.
     /// </summary>
     internal TokenizedBatch Tokenize(IReadOnlyList<string> textsA, IReadOnlyList<string> textsB)
@@ -146,51 +146,11 @@ public sealed class TextTokenizerTransformer : ITransformer
             var tokenIds = new long[seqLen];
             var attentionMask = new long[seqLen];
             var tokenTypeIds = new long[seqLen];
+            long[]? startOffsets = _options.OutputOffsets ? new long[seqLen] : null;
+            long[]? endOffsets = _options.OutputOffsets ? new long[seqLen] : null;
 
-            var tokensA = _tokenizer.EncodeToIds(textsA[i], seqLen, out _, out _);
-            int firstSepIdx = tokensA.Count - 1;
-
-            var combined = new List<int>(tokensA);
-            long[]? startOffsets = null;
-            long[]? endOffsets = null;
-
-            if (_options.OutputOffsets)
-            {
-                startOffsets = new long[seqLen];
-                endOffsets = new long[seqLen];
-
-                var encodedB = _tokenizer.EncodeToTokens(textsB[i], out _);
-                for (int bIdx = 1; bIdx < encodedB.Count; bIdx++)
-                    combined.Add(encodedB[bIdx].Id);
-
-                if (combined.Count > seqLen)
-                    combined.RemoveRange(seqLen, combined.Count - seqLen);
-
-                // Record B segment offsets (relative to B text)
-                for (int bIdx = 1; bIdx < encodedB.Count; bIdx++)
-                {
-                    int combinedIdx = firstSepIdx + bIdx;
-                    if (combinedIdx >= seqLen) break;
-                    startOffsets[combinedIdx] = encodedB[bIdx].Offset.Start.Value;
-                    endOffsets[combinedIdx] = encodedB[bIdx].Offset.End.Value;
-                }
-            }
-            else
-            {
-                var tokensB = _tokenizer.EncodeToIds(textsB[i], seqLen, out _, out _);
-                combined.AddRange(tokensB.Skip(1)); // skip B's CLS
-
-                if (combined.Count > seqLen)
-                    combined.RemoveRange(seqLen, combined.Count - seqLen);
-            }
-
-            // token_type_ids: 0 for A segment (up to and including first SEP), 1 for B segment
-            for (int s = 0; s < combined.Count && s < seqLen; s++)
-            {
-                tokenIds[s] = combined[s];
-                attentionMask[s] = 1;
-                tokenTypeIds[s] = s <= firstSepIdx ? 0 : 1;
-            }
+            TokenizePair(_tokenizer, _options, textsA[i], textsB[i],
+                tokenIds, attentionMask, tokenTypeIds, startOffsets, endOffsets);
 
             allTokenIds[i] = tokenIds;
             allAttentionMasks[i] = attentionMask;
@@ -201,6 +161,73 @@ public sealed class TextTokenizerTransformer : ITransformer
 
         return new TokenizedBatch(allTokenIds, allAttentionMasks, allTokenTypeIds, seqLen,
             allStartOffsets, allEndOffsets);
+    }
+
+    /// <summary>
+    /// Core text-pair tokenization: [BOS] A [SEP] (SEP)? B [SEP].
+    /// Uses EncodeToTokens (which never auto-injects special tokens for any tokenizer type)
+    /// and manually injects BOS/SEP tokens for a uniform approach across BERT, BPE, and SentencePiece.
+    /// </summary>
+    internal static void TokenizePair(
+        Tokenizer tokenizer, TextTokenizerOptions options,
+        string textA, string textB,
+        long[] tokenIds, long[] attentionMask, long[] tokenTypeIds,
+        long[]? startOffsets, long[]? endOffsets)
+    {
+        int seqLen = options.MaxTokenLength;
+        int bosId = options.BosTokenId
+            ?? throw new InvalidOperationException(
+                "Text-pair tokenization requires special token IDs (BOS/CLS and SEP). " +
+                "Load the tokenizer from a directory containing tokenizer_config.json.");
+        int sepId = options.SepTokenId
+            ?? throw new InvalidOperationException(
+                "Text-pair tokenization requires special token IDs (BOS/CLS and SEP). " +
+                "Load the tokenizer from a directory containing tokenizer_config.json.");
+
+        // EncodeToTokens never adds special tokens for any tokenizer type
+        var encodedA = tokenizer.EncodeToTokens(textA, out _);
+        var encodedB = tokenizer.EncodeToTokens(textB, out _);
+
+        // Build: [BOS] A_tokens [SEP] (SEP if double) B_tokens [SEP]
+        var combined = new List<int>(seqLen);
+        combined.Add(bosId);
+
+        for (int j = 0; j < encodedA.Count; j++)
+            combined.Add(encodedA[j].Id);
+
+        combined.Add(sepId);
+        int firstSepIdx = combined.Count - 1;
+
+        if (options.DoubleSeparator)
+            combined.Add(sepId);
+
+        int bStartIdx = combined.Count;
+        for (int j = 0; j < encodedB.Count; j++)
+            combined.Add(encodedB[j].Id);
+
+        combined.Add(sepId);
+
+        if (combined.Count > seqLen)
+            combined.RemoveRange(seqLen, combined.Count - seqLen);
+
+        for (int s = 0; s < combined.Count; s++)
+        {
+            tokenIds[s] = combined[s];
+            attentionMask[s] = 1;
+            tokenTypeIds[s] = s <= firstSepIdx ? 0 : 1;
+        }
+
+        // Record B segment character offsets (for QA answer extraction)
+        if (startOffsets != null && endOffsets != null)
+        {
+            for (int bIdx = 0; bIdx < encodedB.Count; bIdx++)
+            {
+                int combinedIdx = bStartIdx + bIdx;
+                if (combinedIdx >= seqLen) break;
+                startOffsets[combinedIdx] = encodedB[bIdx].Offset.Start.Value;
+                endOffsets[combinedIdx] = encodedB[bIdx].Offset.End.Value;
+            }
+        }
     }
 
     public DataViewSchema GetOutputSchema(DataViewSchema inputSchema)
@@ -354,55 +381,24 @@ internal sealed class TokenizerCursor : DataViewRowCursor
 
         if (_options.SecondInputColumnName != null)
         {
-            // Text-pair tokenization: [CLS] A [SEP] B [SEP]
+            // Text-pair tokenization via shared helper
             var textCol2 = _inputCursor.Schema[_options.SecondInputColumnName];
             var getter2 = _inputCursor.GetGetter<ReadOnlyMemory<char>>(textCol2);
             ReadOnlyMemory<char> textValue2 = default;
             getter2(ref textValue2);
             string text2 = textValue2.ToString();
 
-            var tokensA = _tokenizer.EncodeToIds(text, seqLen, out _, out _);
-            int firstSepIdx = tokensA.Count - 1;
-
-            var combined = new List<int>(tokensA);
-
+            _currentTokenTypeIds ??= new long[seqLen];
             if (_options.OutputOffsets)
             {
                 _currentStartOffsets = new long[seqLen];
                 _currentEndOffsets = new long[seqLen];
-
-                var encodedB = _tokenizer.EncodeToTokens(text2, out _);
-                for (int bIdx = 1; bIdx < encodedB.Count; bIdx++)
-                    combined.Add(encodedB[bIdx].Id);
-
-                if (combined.Count > seqLen)
-                    combined.RemoveRange(seqLen, combined.Count - seqLen);
-
-                // Record B segment offsets (relative to B text)
-                for (int bIdx = 1; bIdx < encodedB.Count; bIdx++)
-                {
-                    int combinedIdx = firstSepIdx + bIdx;
-                    if (combinedIdx >= seqLen) break;
-                    _currentStartOffsets[combinedIdx] = encodedB[bIdx].Offset.Start.Value;
-                    _currentEndOffsets[combinedIdx] = encodedB[bIdx].Offset.End.Value;
-                }
-            }
-            else
-            {
-                var tokensB = _tokenizer.EncodeToIds(text2, seqLen, out _, out _);
-                combined.AddRange(tokensB.Skip(1));
-
-                if (combined.Count > seqLen)
-                    combined.RemoveRange(seqLen, combined.Count - seqLen);
             }
 
-            _currentTokenTypeIds ??= new long[seqLen];
-            for (int s = 0; s < combined.Count && s < seqLen; s++)
-            {
-                _currentTokenIds[s] = combined[s];
-                _currentAttentionMask[s] = 1;
-                _currentTokenTypeIds[s] = s <= firstSepIdx ? 0 : 1;
-            }
+            TextTokenizerTransformer.TokenizePair(
+                _tokenizer, _options, text, text2,
+                _currentTokenIds, _currentAttentionMask, _currentTokenTypeIds,
+                _currentStartOffsets, _currentEndOffsets);
         }
         else if (_options.OutputOffsets)
         {

--- a/src/MLNet.TextInference.Onnx/TextTokenizerTransformer.cs
+++ b/src/MLNet.TextInference.Onnx/TextTokenizerTransformer.cs
@@ -196,10 +196,13 @@ public sealed class TextTokenizerTransformer : ITransformer
             combined.Add(encodedA[j].Id);
 
         combined.Add(sepId);
-        int firstSepIdx = combined.Count - 1;
 
         if (options.DoubleSeparator)
             combined.Add(sepId);
+
+        // Boundary between segment A and segment B for token_type_ids.
+        // Both separators (if double) belong to the A side.
+        int firstSepIdx = combined.Count - 1;
 
         int bStartIdx = combined.Count;
         for (int j = 0; j < encodedB.Count; j++)


### PR DESCRIPTION
## Summary

Rewrites text-pair tokenization to use manual special token injection instead of relying on EncodeToIds auto-injection. Fixes two bugs:

**Bug 1 (Critical):** BPE tokenizers (RoBERTa) don't auto-inject BOS/SEP tokens, so QA models received malformed input causing all answers to be 'unanswerable'.

**Bug 2 (Moderate):** First context word was dropped for all tokenizer types in the OutputOffsets path (bIdx=1 skip), and for BPE in the non-offset path (Skip(1) on tokens without CLS).

## Changes

### TextTokenizerEstimator.cs
- Add internal BosTokenId/SepTokenId/DoubleSeparator properties to TextTokenizerOptions
- Add PopulateSpecialTokens() to extract token IDs from tokenizer_config.json

### TextTokenizerTransformer.cs
- Extract shared TokenizePair() static method using EncodeToTokens + manual BOS/SEP injection
- Both direct API and IDataView cursor paths use the shared method
- B segment tokens start from index 0 (no longer skips first word)
- Supports RoBERTa-style double separator

## Impact

- **RobertaSquad2**: Produces correct answers instead of all 'unanswerable'
- **MiniLMSquad2**: First context word no longer dropped
- **Reranking models**: Correct text-pair encoding for BPE-based rerankers

Fixes #30